### PR TITLE
fixed bug 118 and added network packages to srslte

### DIFF
--- a/srslte/Dockerfile
+++ b/srslte/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && \
     apt-get -y install cmake libfftw3-dev libmbedtls-dev libboost-program-options-dev libconfig++-dev libsctp-dev git \
     libzmq3-dev libboost-system-dev libboost-test-dev libboost-thread-dev libqwt-qt5-dev qtbase5-dev \
     software-properties-common g++ make pkg-config libpython2-dev python-numpy swig libi2c-dev \
-    libboost-program-options-dev libconfig++-dev
+    libboost-program-options-dev libconfig++-dev net-tools iputils-ping
 
 # Install SoapySDR and Lime Suite
 RUN add-apt-repository -y ppa:myriadrf/drivers && \
@@ -44,7 +44,7 @@ RUN add-apt-repository -y ppa:myriadrf/drivers && \
 
 # UHD drivers for USRP
 RUN add-apt-repository ppa:ettusresearch/uhd && \
-    apt update && apt -y install libuhd-dev libuhd4.2.0 uhd-host && \
+    apt update && apt -y install libuhd-dev libuhd4.3.0 uhd-host && \
     uhd_images_downloader
 
 # Get srsGUI, compile and install


### PR DESCRIPTION
Added network packages for srsLTE and closes [bug 118](https://github.com/herlesupreeth/docker_open5gs/issues/118) 