### PR TITLE
Update Dockerfile to support Rpi compilation

### DIFF
--- a/pyhss/Dockerfile
+++ b/pyhss/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update && \
         pkg-config \
         libsystemd-dev \
         libmysqlclient-dev \
+        libsctp-dev \
         gcc \
         mysql-server
         


### PR DESCRIPTION
Raspberry pi compilation of pyhss required libsctp-dev in order to complete.