### PR TITLE
adding QoS N5 to MT Routing

### DIFF
--- a/pcscf/route/mt.cfg
+++ b/pcscf/route/mt.cfg
@@ -6,7 +6,22 @@ route[MT] {
     xnotice("Source IP and Port: ($si:$sp)\n Route-URI: $route_uri\n");
     xnotice("Received IP and Port: ($Ri:$Rp)\n");
     xnotice("Contact header: $ct\n");
+    xnotice("Term UE connection information : IP is $dd and Port is $rp \n");
+    xnotice("Term P-CSCF connection information : IP is $RAi and Port is $RAp \n");
     set_dlg_profile("term");
+    
+#Route N5 Request 
+#
+      if(is_method("INVITE")) {
+          route(N5_INIT_MT_REQ);   
+                 }
+## not sure why on CANCEL its not triggered maybe I'm missing something ?
+
+    if(is_method("CANCEL"))
+    {
+                  route(N5_MTC_TERM); 
+   }  
+    
 #!ifdef WITH_IPSEC
     ipsec_forward("location", IPSEC_FORWARD_FLAGS);
 #!endif
@@ -28,6 +43,25 @@ onreply_route[MT_reply] {
 	# In case of 1xx and 2xx do NAT
 	if(status=~"[12][0-9][0-9]")
 		route(NATMANAGE);
+   
+### N5 PATCH Request
+
+        if (t_check_status("180|183|200") && has_body("application/sdp")){
+        xlog("L_DBG", "About to test if this is a retransmitted reply which is still currently suspended\n");
+        if (t_is_retr_async_reply()) {
+	                xlog("L_DBG", "Dropping retransmitted reply which is still currently suspended\n");
+       		         drop();
+       		           }
+                  route(N5_PATCH_MT_REQ);   
+                 }
+
+## not sure why on CANCEL its not triggered maybe I'm missing something ?
+
+    if(is_method("CANCEL"))
+    {
+                  route(N5_MTC_TERM); 
+   } 
+   
 #!ifdef WITH_RX
         if (t_check_status("183|200") && has_body("application/sdp")){
         xnotice("PCSCF MT_reply: \n Destination URI: $du\n Request URI: $ru\n");
@@ -81,6 +115,24 @@ route[MT_aar_reply]
 # In-Dialog-MT-Requests
 ######################################################################
 route[MT_indialog] {
+
+## N5 PATCH Request
+       
+        if(is_method("INVITE")){
+        xlog("L_ALERT"," InDialog SDP Answer N5 Request for reINVITE\n"); 
+    route(N5_PATCH_REQ);
+       }
+
+## Terminating N5 AppSession after BYE##
+
+    if(is_method("BYE|CANCEL"))
+    {
+                  route(N5_MTC_TERM); 
+   }
+
+#### END of N5 Request 
+
+
     xnotice("PCSCF MT_indialog: \n Destination URI: $du\n Request URI: $ru\n");
     xnotice("Source IP and Port: ($si:$sp)\n Route-URI: $route_uri\n");
     xnotice("Received IP and Port: ($Ri:$Rp)\n");
@@ -150,3 +202,401 @@ route[MT_indialog_aar_reply]
         }
 #!endif
 }
+
+#################################
+## Route Logic for N5 Requests ##
+#################################
+route[N5_INIT_MT_REQ] {
+
+## Storing IDs and IPs from UE into variables to use them later in the N5 Request:
+
+   
+    $var(term_ue_ip) = $dd;
+    $var(term_ue_port) = $rp;
+    $var(pcscf_ip) = $Ri;
+    $var(pcscf_port) = $Rp;
+    
+# now checking it on console if I got what I wanted :
+    xlog("L_INFO", "connection Info for Term UE $var(term_ue_ip) $var(term_ue_port)\n");
+    xlog("L_INFO", "connection Info for P-CSCF is: $var(pcscf_ip) $var(pcscf_port)\n");    
+
+# now trying some way to store IP of Term UE
+    $var(term_user_id_req_ip) = $tU; # should get the user part of the Orig UE from request
+    
+    # Store the IP in the hash table associated with the UE
+    $sht(user_sip_ips=>$var(term_user_id_req_ip)) = $var(term_ue_ip);
+    xlog("L_INFO", "IP Info for Term UE MSISDN $var(term_user_id_req_ip): $var(term_ue_ip)\n");
+    
+# now trying some way to store Port of Term UE
+    $var(term_user_id_req_port) = $tU; # should get the user part of the Orig UE from request
+    
+    # Store the Port in the hash table associated with the UE
+    $sht(user_sip_ports=>$var(user_id_req_port)) = $var(term_ue_port);
+    xlog("L_INFO", "Port Info for UE MSISDN $var(term_user_id_req_port): $var(term_ue_port)\n");
+    
+#### 5G VoNR N5 NPCF Authorization reuqest 
+
+   if(is_method("INVITE")){
+		xlog("L_DBG", "IMS: MTC INVITE TO $tU\n");
+
+    
+## retrieving SDP Connection Info and Media Port for Orig UE ( in case we will start with INVITE), the values should be already there if the call fom UE registred to this P-CSCF, in case the call coming from outside then we need to get them from the initial INVITE
+
+### due to the current limitation on SRS-gNodeB we will not use the values below, they are there just in case the limitation are fixed.
+
+$var(sdp_src_ip) = $sdp(c:ip);
+$var(sdp_src_port) = $sdp(m0:rtp:port);
+$var(sdp_src_rtcp_port) = $sdp(m0:rtcp:port);
+$var(sdp_mline_raw) = $sdp(m0:raw);
+
+# SDP IP Orig Party 
+
+    $var(orig_sdp_id_ue) = $fU; # User Part of the from Header to get the USER 
+    $var(ue_sdp_ip) = $sht(user_sdps_ip=>$var(sdp_id_ue));
+    if $var(ue_sdp_ip) == 0 {
+        xlog("L_INFO", "SDP RTP IP for Orig Party is 0, need to get it from the INVITE, happend if INVITE coming from outside\n");
+# now trying some way to store SDP SRC_IP of Orig Party
+    $var(user_id_sdp_ip) = $fU; # should get the user part of the Orig UE from request
+
+    # Store the AppSession in the hash table associated with the UE
+    $sht(user_sdps_ip=>$var(user_id_sdp_ip)) = $var(sdp_src_ip);
+    xlog("L_INFO", "SDP SRC_IP of External UE $var(user_id_sdp_ip): $var(sdp_src_ip)\n");
+                                   } else {
+    xlog("L_INFO", "SDP IP for UE with MSISDN $var(sdp_id_ue) is: $var(ue_sdp_ip)\n");
+    }
+
+# SDP Port Orig Party
+    
+    $var(sdp_id_ue_port) = $fU; # User Port of the from Header to get the USER 
+    $var(ue_sdp_port) = $sht(user_sdps_port=>$var(sdp_id_ue_port));
+
+    if $var(ue_sdp_port) == 0 {
+        xlog("L_INFO", "SDP RTP port for Orig Party is 0, need to get it from the INVITE, happend if INVITE coming from outside\n");
+# now trying some way to store SDP Media_Port of Orig UE
+    $var(user_id_sdp_port) = $fU; # should get the user part of the Orig UE from request
+
+    # store SDP Media_Port in the hash table associated with the UE
+    $sht(user_sdps_port=>$var(user_id_sdp_port)) = $var(sdp_src_port);
+    xlog("L_INFO", "SDP Media_Port of External UE $var(user_id_sdp_port): $var(sdp_src_port)\n");        
+                                   } else {
+    xlog("L_INFO", "SDP Port for UE with MSISDN $var(sdp_id_ue_port) is: $var(ue_sdp_port)\n");
+    }
+
+    $var(sdp_id_ue_rtcp_port) = $fU; # User Port of the from Header to get the USER 
+    $var(ue_sdp_rtcp_port) = $sht(user_sdps_rtcp_port=>$var(sdp_id_ue_rtcp_port));
+
+    if $var(ue_sdp_port) == 0 {
+        xlog("L_INFO", "SDP RTCP port for Orig Party is 0, need to get it from the INVITE, happend if INVITE coming from outside\n");
+# now trying some way to store SDP RTCP_Media_Port of Orig UE
+    $var(user_id_sdp_rtcp_port) = $fU; # should get the user part of the Orig UE from request
+
+    # Store the RTCP_Media_Port in the hash table associated with the UE
+    $sht(user_sdps_rtcp_port=>$var(user_id_sdp_rtcp_port)) = $var(sdp_src_rtcp_port);
+    xlog("L_INFO", "SDP RTCP_Media_Port of External UE $var(user_id_sdp_rtcp_port): $var(sdp_src_rtcp_port)\n");        
+                                   } else {
+    xlog("L_INFO", "SDP Port for UE with MSISDN $var(sdp_id_ue_rtcp_port) is: $var(ue_sdp_rtcp_port)\n");    
+    }                                   
+
+#### now start to build the N5 Request 
+
+   xlog("L_ALERT","DEBUG: Preparing QoS N5 Message to PCF for 18x Response from term UE\n");
+    
+    xlog("L_ALERT","DEBUG: Initialize empty arrays and objects\n");
+    
+### Initialize empty arrays and objects
+    $var(events) = '[]';
+    $var(medComponents) = '{}';
+    $var(medSubComps) = '{}';
+    $var(evSubsc) = '{}';
+    $var(payload) = '{}';
+    
+### Set afAppId and dnn in payload
+    jansson_set("string", "afAppId", "+g.3gpp.icsi-ref=\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\"", "$var(payload)");  # adding a note that this could be improved in future to get the value SIP Header
+    jansson_set("string", "dnn", "ims", "$var(payload)");
+    
+### Set medComponents
+    jansson_set("integer", "medCompN", 1, "$var(medComp)");
+    jansson_set("string", "qosReference", "qosVoNR", "$var(medComp)");  
+    jansson_set("string", "medType", "AUDIO", "$var(medComp)");
+    jansson_set("array", "codecs", "[\"downlink\\noffer\\n\", \"uplink\\nanswer\\n\"]", "$var(medComp)");
+    
+    ### RTP
+    jansson_set("integer", "fNum", 1, "$var(medSubComp1)");
+    jansson_set("array", "fDescs", "[\"permit out 17 from any to any\", \"permit in 17 from any to any\"]", "$var(medSubComp1)");  ### setting the values to "any" untill SRS-gNodeB supports PDUSessionRessourceModification 
+    jansson_set("string", "fStatus", "ENABLED", "$var(medSubComp1)");
+    jansson_set("string", "marBwDl", "5000 Kbps", "$var(medSubComp1)");  
+    jansson_set("string", "marBwUl", "3000 Kbps", "$var(medSubComp1)"); 
+    jansson_set("string", "flowUsage", "NO_INFO", "$var(medSubComp1)");
+    
+   
+    ### RTCP
+    jansson_set("integer", "fNum", 2, "$var(medSubComp2)");
+    jansson_set("array", "fDescs", "[\"permit out 17 from any to any\", \"permit in 17 from any to any\"]", "$var(medSubComp2)"); ### setting the values to "any" untill SRS-gNodeB supports PDUSessionRessourceModification
+    jansson_set("string", "fStatus", "ENABLED", "$var(medSubComp2)");
+    jansson_set("string", "marBwDl", "5000 Kbps", "$var(medSubComp2)");  
+    jansson_set("string", "marBwUl", "3000 Kbps", "$var(medSubComp2)");  
+    jansson_set("string", "flowUsage", "RTCP", "$var(medSubComp2)");
+    
+    # Merging the flows under MediaSubComponent
+    jansson_set("obj", "0", "$var(medSubComp1)", "$var(medSubComps)");
+    jansson_set("obj", "1", "$var(medSubComp2)", "$var(medSubComps)");
+    jansson_set("obj", "medSubComps", "$var(medSubComps)", "$var(medComp)");
+    
+    jansson_set("obj", "0", "$var(medComp)", "$var(medComponents)");
+    jansson_set("obj", "medComponents", "$var(medComponents)", "$var(payload)");
+    
+    xlog("L_ALERT","DEBUG: Set evSubsc\n");
+    
+### Set evSubsc
+    jansson_set("string", "event", "QOS_NOTIF", "$var(event1)");
+    jansson_set("string", "notifMethod", "PERIODIC", "$var(event1)");  
+    jansson_append("obj", "", "$var(event1)", "$var(events)");
+    jansson_set("string", "event", "ANI_REPORT", "$var(event2)");
+    jansson_set("string", "notifMethod", "ONE_TIME", "$var(event2)");
+    jansson_append("obj", "", "$var(event2)", "$var(events)");
+    jansson_set("array", "events", "$var(events)", "$var(evSubsc)");
+    
+    jansson_set("obj", "evSubsc", "$var(evSubsc)", "$var(payload)");
+    
+### Set other parameters in payload
+    jansson_set("string", "notifUri", "http://172.22.0.21:7777", "$var(payload)");
+    jansson_set("string", "sponStatus", "SPONSOR_DISABLED", "$var(payload)");
+    jansson_set("string", "gpsi", "msisdn-$tU", "$var(payload)");
+    jansson_set("string", "suppFeat", "2", "$var(payload)");
+    jansson_set("string", "ueIpv4", "$dd", "$var(payload)");
+    
+    ### Assemble the final JSON request
+    jansson_set("obj", "ascReqData", "$var(payload)", "$var(json_request)");
+
+    xlog("L_ALERT","DEBUG: Set headers for the HTTP2 Request\n");    
+### Set headers    
+    $var(time_now)=$_s($timef(%a, %d %b %Y %H:%M:%S %Z));
+    xlog("Today is $var(time_now)\n");
+     
+    $var(headers) = "Content-Type: application/json\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-discovery-target-nf-type: NRF\r\n";
+    $var(headers) = $var(headers) + "accept: application/json\r\n";
+    $var(headers) = $var(headers) + "accept: application/problem+json\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-max-rsp-time: 10000\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-discovery-service-names: npcf-policyauthorization\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-sender-timestamp: " + $var(time_now);
+
+    
+    xlog("L_ALERT","DEBUG: Sending the request to PCF\n");    
+### Send the request to PCF
+    http_client_request_v2pk("POST", "http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$var(json_request)", "$var(headers)", "$var(result)" );
+    xlog("HTTP response: $var(result)\n");
+    xlog("L_ALERT", "response header: $curlerror(error)\n");
+    xlog("L_ALERT", "response header: $var(response_code)\n");
+    xlog("L_ALERT", "response header: $httprhdr(location)\n");
+
+# Now I will retrieve the AppSessionID out of the location Header it should be always at the end 
+# Example URL: "http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions/(someSessionID)"
+    
+# Firt store the url of the lcoation Header in var
+    $var(url) = $httprhdr(location);
+    
+    # Get the length of the URL
+    $var(len) = $(var(url){s.len});
+    
+    # Initialize the position variable to the length of the URL
+    $var(pos) = $var(len);
+    
+    # Find the position of the last slash by iterating backwards
+    while ($var(pos) > 0) {
+      $var(pos) = $var(pos) - 1;
+      if ($(var(url){s.substr,$var(pos),1}) == "/") {
+          # We've found the last slash
+          break;
+      }
+    }
+    
+# Extract the substring after the last slash
+# now doing some magic
+    $var(start_pos) = $var(pos) + 1;
+    $var(end_pos) = $var(len) - $var(start_pos);
+    $var(mtc_app_session) = $(var(url){s.substr,$var(start_pos),$var(end_pos)});
+    
+# now checking it on console if I got what I wanted :
+    xlog("L_INFO", "AppSession for user $tU is: $var(mtc_app_session)\n");
+
+# now trying some way to store AppSession with the registred UE
+    $var(term_user_id) = $tU; # should get the user part of the Orig UE
+
+    # Store the AppSession in the hash table associated with the UE
+    $sht(user_data=>$var(term_user_id)) = $var(mtc_app_session);
+    xlog("L_INFO", "Stored AppSession for user $var(term_user_id): $var(mtc_app_session)\n");
+}
+
+}
+############
+#############
+#############
+
+route[N5_PATCH_MT_REQ] {
+        
+        
+		xlog("L_DBG", "IMS: Received 183/200 from Term UE\n");
+
+
+## retrieving SDP Connection Info and Media Port for UE 
+    $var(sdp_id_ue) = $fU; # User Part of the from Header to get the USER 
+    $var(ue_sdp_ip) = $sht(user_sdps_ip=>$var(sdp_id_ue));
+    xlog("L_INFO", "SDP IP for UE with MSISDN $var(sdp_id_ue) is: $var(ue_sdp_ip)\n");
+
+    $var(sdp_id_ue_port) = $fU; # User Port of the from Header to get the USER 
+    $var(ue_sdp_port) = $sht(user_sdps_port=>$var(sdp_id_ue_port));
+    xlog("L_INFO", "SDP Port for UE with MSISDN $var(sdp_id_ue_port) is: $var(ue_sdp_port)\n");
+
+
+    $var(sdp_id_ue_rtcp_port) = $fU; # User Port of the from Header to get the USER 
+    $var(ue_sdp_rtcp_port) = $sht(user_sdps_rtcp_port=>$var(sdp_id_ue_rtcp_port));
+    xlog("L_INFO", "SDP Port for UE with MSISDN $var(sdp_id_ue_rtcp_port) is: $var(ue_sdp_rtcp_port)\n");    
+    
+## retrieving SDP Connection Info from SDP Answer 
+    $var(sdp_answ_ip) = $sdp(c:ip);
+    $var(sdp_answ_port) = $sdp(m0:rtp:port);
+    $var(sdp_answ_rtcp_port) = $sdp(m0:rtcp:port);
+    $var(sdp_answ_codec) = $(rb{line.sw,a=rtpmap}{s.select,1, });
+    xlog("L_ALERT", "SDP Answer connection Info is: $var(sdp_answ_ip), RTP port $var(sdp_answ_port), RTCP Port $var(sdp_answ_rtcp_port) and codec is $var(sdp_answ_codec)\n");
+    
+## Retrieveing AppSession from initial INVITE N5 Request
+    $var(mtc_resp_app_id) = $tU; # User Part of the from Header to get the USER 
+    $var(user_appsess_mtc_rep) = $sht(user_data=>$var(mtc_resp_app_id));
+    xlog("L_INFO", "Stored MTC AppSession for user $var(mtc_resp_app_id): $var(user_appsess_mtc_rep)\n");
+
+#### now start to build the N5 Request 
+
+   xlog("L_ALERT","DEBUG: Preparing PATCH N5 Message for SDP Answer\n");
+    
+    xlog("L_ALERT","DEBUG: Initialize empty arrays and objects\n");
+    
+### Initialize empty arrays and objects
+    $var(events) = '[]';
+    $var(medComponents) = '{}';
+    $var(medSubComps) = '{}';
+    $var(evSubsc) = '{}';
+    $var(payload) = '{}';
+    
+### Set afAppId and dnn in payload
+    jansson_set("string", "afAppId", "+g.3gpp.icsi-ref=\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\"", "$var(payload)");
+    jansson_set("string", "dnn", "ims", "$var(payload)");
+    
+### Set medComponents
+    jansson_set("integer", "medCompN", 1, "$var(medComp)");
+#    jansson_set("string", "qosReference", "qosVoNR", "$var(medComp)");  # not all element in PATCH/Merge request are needed only the chanegd one, could be reenabled if needed 
+    jansson_set("string", "medType", "AUDIO", "$var(medComp)");
+    jansson_set("array", "codecs", "[\"downlink\\n$var(sdp_answ_codec)\\n\", \"uplink\\n$var(sdp_answ_codec)\\n\"]", "$var(medComp)");
+    
+     ### RTP
+    jansson_set("integer", "fNum", 1, "$var(medSubComp1)");
+    jansson_set("array", "fDescs", "[\"permit out 17 from any to $var(sdp_answ_ip) $var(sdp_answ_port)\", \"permit in 17 from $var(sdp_answ_ip) $var(sdp_answ_port) to any\"]", "$var(medSubComp1)");
+    jansson_set("string", "fStatus", "ENABLED", "$var(medSubComp1)");
+#    jansson_set("string", "marBwDl", "5000 Kbps", "$var(medSubComp1)");  # commented out BW accourding to Open5GC code if they are not there they will be taken from WEBGUI, could be reenabled if needed
+#    jansson_set("string", "marBwUl", "3000 Kbps", "$var(medSubComp1)");  # commented out BW accourding to Open5GC code if they are not there they will be taken from WEBGUI, could be reenabled if needed
+    jansson_set("string", "flowUsage", "NO_INFO", "$var(medSubComp1)");
+    
+   
+    ### RTCP
+    jansson_set("integer", "fNum", 2, "$var(medSubComp2)");
+    jansson_set("array", "fDescs", "[\"permit out 17 from any to $var(sdp_answ_ip) $var(sdp_answ_rtcp_port)\", \"permit in 17 from $var(sdp_answ_ip) $var(sdp_answ_rtcp_port) to any\"]", "$var(medSubComp2)");
+    jansson_set("string", "fStatus", "ENABLED", "$var(medSubComp2)");
+#    jansson_set("string", "marBwDl", "5000 Kbps", "$var(medSubComp2)");  # commented out BW accourding to Open5GC code if they are not there they will be taken from WEBGUI, could be reenabled if needed
+#    jansson_set("string", "marBwUl", "3000 Kbps", "$var(medSubComp2)");  # commented out BW accourding to Open5GC code if they are not there they will be taken from WEBGUI, could be reenabled if needed
+    jansson_set("string", "flowUsage", "RTCP", "$var(medSubComp2)");
+    
+    # Merging the flows under MediaSubComponent
+    jansson_set("obj", "0", "$var(medSubComp1)", "$var(medSubComps)");
+    jansson_set("obj", "1", "$var(medSubComp2)", "$var(medSubComps)");
+    jansson_set("obj", "medSubComps", "$var(medSubComps)", "$var(medComp)");
+    
+    jansson_set("obj", "0", "$var(medComp)", "$var(medComponents)");
+    jansson_set("obj", "medComponents", "$var(medComponents)", "$var(payload)");
+    
+    xlog("L_ALERT","DEBUG: Set evSubsc\n");
+    
+### Set evSubsc
+    jansson_set("string", "event", "QOS_NOTIF", "$var(event1)");
+    jansson_set("string", "notifMethod", "PERIODIC", "$var(event1)");  
+    jansson_append("obj", "", "$var(event1)", "$var(events)");
+    jansson_set("string", "event", "ANI_REPORT", "$var(event2)");
+    jansson_set("string", "notifMethod", "ONE_TIME", "$var(event2)");
+    jansson_append("obj", "", "$var(event2)", "$var(events)");
+    jansson_set("array", "events", "$var(events)", "$var(evSubsc)");
+    
+    jansson_set("obj", "evSubsc", "$var(evSubsc)", "$var(payload)");
+    
+### Set other parameters in payload
+    jansson_set("string", "notifUri", "http://172.22.0.21:7777", "$var(payload)");
+#    jansson_set("string", "sponStatus", "SPONSOR_DISABLED", "$var(payload)");  # not all element in PATCH/Merge request are needed only the chanegd one, could be reenabled if needed
+#    jansson_set("string", "gpsi", "msisdn-$tU", "$var(payload)");              # not all element in PATCH/Merge request are needed only the chanegd one, could be reenabled if needed 
+    jansson_set("string", "suppFeat", "2", "$var(payload)");                   # not all element in PATCH/Merge request are needed only the chanegd one, could be reenabled if needed 
+#    jansson_set("string", "ueIpv4", "$si", "$var(payload)");  # not all element in PATCH/Merge request are needed only the chanegd one, could be reenabled if needed 
+    
+    ### Assemble the final JSON request
+    jansson_set("obj", "ascReqData", "$var(payload)", "$var(json_request)");
+
+    xlog("L_ALERT","DEBUG: Set headers for the HTTP2 Request\n");    
+### Set headers    
+    $var(time_now)=$_s($timef(%a, %d %b %Y %H:%M:%S %Z));
+    xlog("Today is $var(time_now)\n");
+     
+    $var(headers) = "Content-Type: application/merge-patch+json\r\n"; # added content-type an set it to "application/merge-patch+json" fo compatibility with RFC7386 for JSON PATCH/Merge
+    $var(headers) = $var(headers) + "3gpp-sbi-discovery-target-nf-type: NRF\r\n";
+    $var(headers) = $var(headers) + "accept: application/json\r\n";
+    $var(headers) = $var(headers) + "accept: application/problem+json\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-max-rsp-time: 10000\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-discovery-service-names: npcf-policyauthorization\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-sender-timestamp: " + $var(time_now);
+
+    
+    xlog("L_ALERT","DEBUG: Sending the request to PCF\n");    
+### Send the request to PCF
+    http_client_request_v2pk("PATCH", "http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions/$var(user_appsess_mtc_rep)", "$var(json_request)", "$var(headers)", "$var(result)" );
+    xlog("HTTP response: $var(result)\n");
+    xlog("L_ALERT", "response header: $curlerror(error)\n");
+    xlog("L_ALERT", "response header: $var(response_code)\n");
+    xlog("L_ALERT", "response header: $httprhdr(location)\n");
+
+}
+
+########################################
+######### END of 5G VoNR N5 Request ####
+########################################
+route[N5_MTC_TERM] {
+
+## something need to be clear here about BYE ;( To/From Headers!!!
+
+
+    xlog("L_ALERT","Terminating AppSession For Call fom User $fu due to call END\n"); 
+    # Retrieveing and paying attention to whom ended teh call
+    $var(mtc_resp_app_id) = $tU; # User Part of the from Header to get the USER 
+    $var(user_appsess_mtc_rep) = $sht(user_data=>$var(mtc_resp_app_id));
+    if $var(user_appsess_mtc_rep) == 0 {
+    xlog("L_INFO", "BYE sent from Term UE, doing alternative Method\n");
+    
+    # Retrieveing and paying attention to whom ended teh call
+    $var(mtc_resp_app_id) = $fU; # User Part of the from Header to get the USER 
+    $var(user_appsess_mtc_rep) = $sht(user_data=>$var(mtc_resp_app_id));
+    xlog("L_INFO", "Alt-Method : Terminating Stored AppSession for user $var(mtc_resp_app_id): $var(user_appsess_mtc_rep)\n");    
+    } else {
+    xlog("L_INFO", "BYE sent from Orig UE, doing normal Method\n");
+    xlog("L_INFO", "Normal Method : Stored MTC AppSession for user $var(mtc_resp_app_id): $var(user_appsess_mtc_rep)\n");
+    }
+
+    
+    $var(headers) = "X-SIP-Status: De-Registration\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-discovery-target-nf-type: NRF\r\n";
+    $var(headers) = $var(headers) + "accept: application/json\r\n";
+    $var(headers) = $var(headers) + "accept: application/problem+json\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-max-rsp-time: 10000\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-discovery-service-names: npcf-policyauthorization\r\n";
+    $var(headers) = $var(headers) + "3gpp-sbi-sender-timestamp: " + $var(time_now);
+    
+    http_client_request_v2pk("POST", "http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions/$var(user_appsess_mtc_rep)/delete", "$var(json_request)", "$var(headers)", "$var(result)" );
+    xlog("Termination resuls: $var(result)\n");
+    xlog("L_ALERT", "response header: $curlerror(error)\n");
+    xlog("L_ALERT", "response header: $var(response_code)\n");
+    xlog("L_ALERT", "response header: $httprhdr(location)\n");
+    
+}    


### PR DESCRIPTION
adding QoS N5 to MT Routing to enable N5 QoS on Term UE.

done some extra logic in case the call is from outside the IMS ( over IBCF ), as during the testing I had only one 5G Enabled device, it should also work without any issue with two devices.

I discovered some issue with releasing the session after call ends with BYE, as I depend on the To/From Header, I had to add extra logic, the same goes to the MO.cfg file, which needs an update also, I could need a ne HTable for MTC AppSession in case it cause some unexpected conflict. 

I tried to add logic to delete the session if the call is canceled, for some reason I was unable to, maybe I'm not putting the "if" in the right place?

I notice also that the NotifyURI in the MO/MT/Register it uses another port that what you finally configured for NGHTTP2 Server I set the port in this file MT.cfg TO 7777, 

currently I'm setting the Flow rules to "any" as long as srsGNB does not support Session Modification, but I left the logic active to easily implanting it back  ( need only to replace "any" with the suitable variable).

I would be very happy if someone can also test and report back in case of issues ;)

As usual your reviews are welcome ;)