### PR TITLE
Linux kernel dropping packets from the UPF to gNB

### DIFF
--- a/sa-deploy.yaml
+++ b/sa-deploy.yaml
@@ -212,7 +212,8 @@ services:
       - -c
       - |
         ip ro add ${UE_IPV4_INTERNET} via ${UPF_IP} && \
-        iptables -t nat -A POSTROUTING -s ${UE_IPV4_INTERNET} -j MASQUERADE
+        iptables -t nat -A POSTROUTING -s ${UE_IPV4_INTERNET} -j MASQUERADE && \
+        sysctl -w net.ipv4.conf.all.accept_local=1
         echo "done"
         tail -f /dev/null
   amf:

--- a/sa-vonr-deploy.yaml
+++ b/sa-vonr-deploy.yaml
@@ -212,7 +212,8 @@ services:
       - -c
       - |
         ip ro add ${UE_IPV4_INTERNET} via ${UPF_IP} && \
-        iptables -t nat -A POSTROUTING -s ${UE_IPV4_INTERNET} -j MASQUERADE
+        iptables -t nat -A POSTROUTING -s ${UE_IPV4_INTERNET} -j MASQUERADE && \
+        sysctl -w net.ipv4.conf.all.accept_local=1
         echo "done"
         tail -f /dev/null
   amf:


### PR DESCRIPTION
Hi @herlesupreeth

First of all thanks for the repository, i've used it for a while and has helped me a lot!

After trying out your eupf branch i've notice that i couldnt ping anything from the UEs, both with simulated srsUE and real smartphones. After going through the traces i concluded that the eUPF implementation was doing what it was supposed to do and that the packets to the gNB were being dropped by the linux kernel. 

Following this [forum](https://www.linuxquestions.org/questions/linux-networking-3/dropped-udp-packets-4175502834/), it suggests that Linux kernel drops incoming packets which source address match the local interface address. And to solve this issue you can enable _accept_local_ in ipv4 configurations.

So i used your eupf-routes container to reflect this change on the host machine, its working for me without any other modifications. Let me know if you've seen this issue on your side and if so, if this fixes it for you!