### PR TITLE
Use latest srsRAN gnb config file syntax

### DIFF
--- a/srsran/gnb.yml
+++ b/srsran/gnb.yml
@@ -1,6 +1,13 @@
-amf:
-  addr: AMF_IP                                                    # The address or hostname of the AMF.
-  bind_addr: SRS_GNB_IP                                           # A local IP that the gNB binds to for traffic from the AMF.
+cu_cp:
+  amf:
+    addr: AMF_IP                                                  # The address or hostname of the AMF.
+    bind_addr: SRS_GNB_IP                                         # A local IP that the gNB binds to for traffic from the AMF.
+    supported_tracking_areas:                                     # Sets the list of tracking areas supported by this AMF.
+      - tac: 1                                                    # Tracking area code (needs to match the core configuration).
+        plmn_list:                                                # The list of PLMN items supported for this Tracking Area.
+          - plmn: "PLMN"                                          # PLMN broadcasted by the gNB.
+            tai_slice_support_list:                               # The list of TAI slices for this PLMN item.
+              - sst: 1                                            # Sets the Slice Service Type.
 
 ru_sdr:
   device_driver: uhd                                            # The RF driver name.
@@ -35,6 +42,8 @@ pcap:
   e1ap_enable: false                                              # Set to true to enable E1AP PCAPs.
   e1ap_filename: /mnt/srsran/gnb_e1ap.pcap                        # Path where the E1AP PCAP is stored.
   e2ap_enable: false                                              # Set to true to enable E2AP PCAPs.
-  e2ap_filename: /mnt/srsran/gnb_e2ap.pcap                        # Path where the E2AP PCAP is stored.
+  e2ap_cu_cp_filename: /mnt/srsran/cu_cp_e2ap.pcap                # Path where E2AP CU-CP PCAP is stored.
+  e2ap_cu_up_filename: /mnt/srsran/cu_up_e2ap.pcap                # Path where E2AP CU-UP PCAP is stored.
+  e2ap_du_filename: /mnt/srsran/du_e2ap.pcap                      # Path where E2AP CU PCAP is stored.
   n3_enable: false                                                # Set to true to enable N3 PCAPs.
   n3_filename: /mnt/srsran/gnb_n3.pcap                            # Path where the N3 PCAP is stored.

--- a/srsran/gnb_zmq.yml
+++ b/srsran/gnb_zmq.yml
@@ -1,6 +1,13 @@
-amf:
-  addr: AMF_IP                                                                                # The address or hostname of the AMF.
-  bind_addr: SRS_GNB_IP                                                                       # A local IP that the gNB binds to for traffic from the AMF.
+cu_cp:
+  amf:
+    addr: AMF_IP                                                                              # The address or hostname of the AMF.
+    bind_addr: SRS_GNB_IP                                                                     # A local IP that the gNB binds to for traffic from the AMF.
+    supported_tracking_areas:                                                                 # Sets the list of tracking areas supported by this AMF.
+      - tac: 1                                                                                # Tracking area code (needs to match the core configuration).
+        plmn_list:                                                                            # The list of PLMN items supported for this Tracking Area.
+          - plmn: "PLMN"                                                                      # PLMN broadcasted by the gNB.
+            tai_slice_support_list:                                                           # The list of TAI slices for this PLMN item.
+              - sst: 1                                                                        # Sets the Slice Service Type.
 
 ru_sdr:
   device_driver: zmq                                                                          # The RF driver name.
@@ -41,6 +48,8 @@ pcap:
   e1ap_enable: false                                                                          # Set to true to enable E1AP PCAPs.
   e1ap_filename: /mnt/srsran/gnb_e1ap.pcap                                                    # Path where the E1AP PCAP is stored.
   e2ap_enable: false                                                                          # Set to true to enable E2AP PCAPs.
-  e2ap_filename: /mnt/srsran/gnb_e2ap.pcap                                                    # Path where the E2AP PCAP is stored.
+  e2ap_cu_cp_filename: /mnt/srsran/cu_cp_e2ap.pcap                                            # Path where E2AP CU-CP PCAP is stored.
+  e2ap_cu_up_filename: /mnt/srsran/cu_up_e2ap.pcap                                            # Path where E2AP CU-UP PCAP is stored.
+  e2ap_du_filename: /mnt/srsran/du_e2ap.pcap                                                  # Path where E2AP CU PCAP is stored.
   n3_enable: false                                                                            # Set to true to enable N3 PCAPs.
   n3_filename: /mnt/srsran/gnb_n3.pcap                                                        # Path where the N3 PCAP is stored.


### PR DESCRIPTION
Update srsRAN config files with new syntax.

In the commit [0ee1be4](https://github.com/herlesupreeth/docker_open5gs/commit/0ee1be4ae70df086ea62823592ffcb82fc11dfca), the version of srsRAN code is updated from [4ac5300](https://github.com/srsran/srsRAN_Project/commit/4ac5300d4927b5199af69e6bc2e55d061fc33652) to [e5d5b44](https://github.com/srsran/srsRAN_Project/commit/e5d5b44b92cf18d1bd1736da0148e5f9cce3721d). 
As shown in [ef983b6](https://github.com/srsran/srsRAN_Project/commit/ef983b64bdaf6dd77918ffc5365e5a97a8088aef), the syntax for the gnb configuration file changed. The new documentation is available [here](https://docs.srsran.com/projects/project/en/latest/user_manuals/source/config_ref.html).

Without this change, the gnb fails to initialize with the message `INI was not able to parse amf.++`.