### PR TITLE
Fix OAI binary path

### DIFF
--- a/oai/enb_dockerfile
+++ b/oai/enb_dockerfile
@@ -50,5 +50,5 @@ RUN . ./oaienv && cd cmake_targets && \
     ./build_oai -I -w USRP --eNB --verbose-compile
 
 
-CMD . ./oaienv && /mnt/oai/oai_init.sh && cd cmake_targets/lte_build_oai/build && \
+CMD . ./oaienv && /mnt/oai/oai_init.sh && cd cmake_targets/ran_build/build && \
     ./lte-softmodem -O $OPENAIR_DIR/targets/PROJECTS/GENERIC-LTE-EPC/CONF/enb.band7.tm1.50PRB.usrpb210.conf -d


### PR DESCRIPTION
Hi @herlesupreeth!

I've noticed that the "lte-softmodem" binary file is now compiled in the ```cmake_targets/ran_build/build``` path (have a look here: https://github.com/herlesupreeth/docker_open5gs/actions/runs/12835352690/job/35794616248#step:6:6255), but in the enb_dockerfile it still points to ```cmake_targets/lte_build_oai/build```.

I have fixed the error as otherwise the pre-build Docker image is broken.

Best regards,

Signed-off-by: Aitor Iturrioz <aiturrioz@tknika.eus>