### PR TITLE
enabling VoNR for OpenSIPS, first implementations

### DIFF
--- a/opensips_ims_pcscf/opensips_vonr.cfg
+++ b/opensips_ims_pcscf/opensips_vonr.cfg
@@ -348,9 +348,8 @@ route[dm_send_aar] {
 	switch ($param(1)) {
 
 	case "control":
-#### Doing N5 QoS for Registration :
 
-		if ($ipsec(ip) != NULL) {
+  		if ($ipsec(ip) != NULL) {
 			$var(src_ip) = $ipsec_ue(ip);
 			$var(src_port) = $ipsec_ue(port-c);
 			$var(dst_ip) = $ipsec(ip);
@@ -375,43 +374,38 @@ route[dm_send_aar] {
 		$var(ueIpv4) = $var(src_ip);
 
 		$json(nf_reg_body) = "{
-							\"ascReqData\":{
-								\"afAppId\": \""+$var(afAppId)+"\",
-								\"dnn\": \""+$var(dnn)+"\" ,
-								\"medComponents\":{
-												\"0\":{
-														\"medCompN\":0,
-														\"qosReference\":\"qosVoNR\",
-														\"medType\":\"CONTROL\",
-														\"medSubComps\":{ 
-																		\"0\": 
-																			{
-																			\"fNum\":0,
-																			\"fDescs\": "+$json(array1)+",
-																			\"fStatus\":\"ENABLED\",
-																			\"flowUsage\":\"AF_SIGNALLING\"
-																			}
-																		}
-														}
-													},
-							\"evSubsc\":{ \"events\": "+$var(events)+"},
-							\"notifUri\": \""+$var(notifUri)+"\" ,
-							\"sponStatus\": \""+$var(sponStatus)+"\",
-							\"supi\": \""+$var(supi)+"\",
-							\"suppFeat\": \""+$var(suppFeat)+"\",
-							\"ueIpv4\": \""+$var(ueIpv4)+"\"
+				\"ascReqData\":{
+					\"afAppId\": \""+$var(afAppId)+"\",
+					\"dnn\": \""+$var(dnn)+"\" ,
+					\"medComponents\":{
+						\"0\":{
+							\"medCompN\":0,
+							\"qosReference\":\"qosVoNR\",
+							\"medType\":\"CONTROL\",
+							\"medSubComps\":{ 
+									\"0\":{
+	 									\"fNum\":0,
+										\"fDescs\": "+$json(array1)+",
+										\"fStatus\":\"ENABLED\",
+										\"flowUsage\":\"AF_SIGNALLING\"
 										}
-							}";
+									}
+								}
+							},
+					\"evSubsc\":{ \"events\": "+$var(events)+"},
+					\"notifUri\": \""+$var(notifUri)+"\" ,
+					\"sponStatus\": \""+$var(sponStatus)+"\",
+					\"supi\": \""+$var(supi)+"\",
+					\"suppFeat\": \""+$var(suppFeat)+"\",
+					\"ueIpv4\": \""+$var(ueIpv4)+"\"
+						}
+				}";
 		rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_reg_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
 		xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
 		xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
 		xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
 		xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");
 		break;
-
-####### End N5 QoS for Registration
-
-#### Doing N5 QoS for Call :
 
 	case "audio":
 		$var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
@@ -428,52 +422,50 @@ route[dm_send_aar] {
 		$var(ueIpv4) = $avp(ip);
 	
 		$json(nf_call_body) = "{
-							\"ascReqData\": {
-								\"afAppId\": \""+$var(afAppId)+"\",
-								\"dnn\": \""+$var(dnn)+"\" ,
-								\"medComponents\":{ 
-												\"0\":{	
-														\"medCompN\":0,
-														\"qosReference\":\"qosVoNR\",
-														\"medType\":\"AUDIO\", 
-														\"medSubComps\":{
-																	\"0\": {
-																		\"fNum\":1, 
-																		\"fDescs\": "+$json(array1)+", 
-																		\"fStatus\":\"ENABLED\", 
-																		\"marBwDl\":\"5000 Kbps\", 
-																		\"marBwUl\":\"3000 Kbps\", 
-																		\"flowUsage\":\"NO_INFO\"
-																		},
-																	\"1\":{
-																		\"fNum\":2, 
-																		\"fDescs\": "+$json(array2)+", 
-																		\"fStatus\":\"ENABLED\", 
-																		\"marBwDl\":\"5000 Kbps\", 
-																		\"marBwUl\":\"3000 Kbps\", 
-																		\"flowUsage\":\"RTCP\"
-																			}
-																	}
-													}
-												},
-								\"evSubsc\":{ \"events\": "+$var(events)+"},
-								\"notifUri\": \""+$var(notifUri)+"\" ,
-								\"sponStatus\": \""+$var(sponStatus)+"\",
-								\"supi\": \""+$var(supi)+"\",
-								\"suppFeat\": \""+$var(suppFeat)+"\",
-								\"ueIpv4\": \""+$var(ueIpv4)+"\" 
-											}
-								}";
+				\"ascReqData\": {
+					\"afAppId\": \""+$var(afAppId)+"\",
+					\"dnn\": \""+$var(dnn)+"\" ,
+					\"medComponents\":{ 
+						\"0\":{	
+							\"medCompN\":0,
+							\"qosReference\":\"qosVoNR\",
+							\"medType\":\"AUDIO\", 
+							\"medSubComps\":{
+									\"0\":{
+										\"fNum\":1, 
+										\"fDescs\": "+$json(array1)+", 
+										\"fStatus\":\"ENABLED\", 
+										\"marBwDl\":\"5000 Kbps\", 
+										\"marBwUl\":\"3000 Kbps\", 
+										\"flowUsage\":\"NO_INFO\"
+										},
+									\"1\":{
+										\"fNum\":2, 
+										\"fDescs\": "+$json(array2)+", 
+										\"fStatus\":\"ENABLED\", 
+										\"marBwDl\":\"5000 Kbps\", 
+										\"marBwUl\":\"3000 Kbps\", 
+										\"flowUsage\":\"RTCP\"
+										}
+									}
+								}
+							},
+					\"evSubsc\":{ \"events\": "+$var(events)+"},
+					\"notifUri\": \""+$var(notifUri)+"\" ,
+					\"sponStatus\": \""+$var(sponStatus)+"\",
+					\"supi\": \""+$var(supi)+"\",
+					\"suppFeat\": \""+$var(suppFeat)+"\",
+					\"ueIpv4\": \""+$var(ueIpv4)+"\" 
+					}
+				}";
 	rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_call_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
 	xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
 	xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
 	xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
 	xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");   
 	break;	   
-
-		}
+	}
 }
-
 route[session_termination] {
 	if ($si != "SCSCF_IP")
 		rtpengine_delete();

--- a/opensips_ims_pcscf/opensips_vonr.cfg
+++ b/opensips_ims_pcscf/opensips_vonr.cfg
@@ -1,0 +1,487 @@
+#
+# OpenSIPS residential configuration script
+#     by OpenSIPS Solutions <team@opensips-solutions.com>
+#
+# This script was generated via "make menuconfig", from
+#   the "Residential" scenario.
+# You can enable / disable more features / functionalities by
+#   re-generating the scenario with different options.#
+#
+# Please refer to the Core CookBook at:
+#      https://opensips.org/Resources/DocsCookbooks
+# for a explanation of possible statements, functions and parameters.
+#
+
+
+####### Global Parameters #########
+
+/* uncomment the following lines to enable debugging */
+#debug_mode=yes
+
+log_level=3
+xlog_level=3
+#mem_log=6
+log_stderror=yes
+log_stdout=yes
+log_facility=LOG_LOCAL0
+
+udp_workers=4
+
+/* uncomment the next line to enable the auto temporary blacklisting of
+   not available destinations (default disabled) */
+#disable_dns_blacklist=no
+
+/* uncomment the next line to enable IPv6 lookup after IPv4 dns
+   lookup failures (default disabled) */
+#dns_try_ipv6=yes
+
+dns=no
+
+socket=udp:PCSCF_IP:5060
+socket=tcp:PCSCF_IP:5060
+socket=ipsec:PCSCF_IP:6100,5100
+
+alias="pcscf.IMS_DOMAIN"
+
+
+
+#set module path
+mpath="/usr/lib/x86_64-linux-gnu/opensips/modules"
+
+####### Modules Section ########
+
+#### MYSQL module
+loadmodule "db_mysql.so"
+
+#### SIGNALING module
+loadmodule "signaling.so"
+
+#### StateLess module
+loadmodule "sl.so"
+
+#### Transaction Module
+loadmodule "tm.so"
+modparam("tm", "fr_timeout", 5)
+modparam("tm", "fr_inv_timeout", 30)
+modparam("tm", "restart_fr_on_each_reply", 0)
+modparam("tm", "onreply_avp_mode", 1)
+
+#### Record Route Module
+loadmodule "rr.so"
+/* do not append from tag to the RR (no need for this script) */
+modparam("rr", "append_fromtag", 0)
+
+#### MAX ForWarD module
+loadmodule "maxfwd.so"
+
+#### NATHELPER module
+loadmodule "nathelper.so"
+
+#### SIP MSG OPerationS module
+loadmodule "sipmsgops.so"
+
+#### FIFO Management Interface
+loadmodule "mi_fifo.so"
+modparam("mi_fifo", "fifo_name", "/run/opensips/opensips_fifo")
+modparam("mi_fifo", "fifo_mode", 0666)
+
+#### USeR LOCation module
+loadmodule "usrloc.so"
+modparam("usrloc", "nat_bflag", "NAT")
+modparam("usrloc", "mi_dump_kv_store", 1)
+modparam("usrloc", "working_mode_preset", "single-instance-no-db")
+
+#### REGISTRAR module
+loadmodule "registrar.so"
+modparam("registrar", "tcp_persistent_flag", "TCP_PERSISTENT")
+/* uncomment the next line not to allow more than 10 contacts per AOR */
+#modparam("registrar", "max_contacts", 10)
+
+#### ACCounting module
+loadmodule "acc.so"
+/* what special events should be accounted ? */
+modparam("acc", "early_media", 0)
+modparam("acc", "report_cancels", 0)
+/* by default we do not adjust the direct of the sequential requests.
+   if you enable this parameter, be sure to enable "append_fromtag"
+   in "rr" module */
+modparam("acc", "detect_direction", 0)
+
+#### proto_udp module
+loadmodule "dispatcher.so"
+
+loadmodule "proto_udp.so"
+loadmodule "proto_tcp.so"
+loadmodule "proto_ipsec.so"
+loadmodule "dialog.so"
+
+#### dbtext module
+loadmodule "db_text.so"
+modparam("dispatcher", "db_url", "text:///etc/opensips/db")
+
+modparam("proto_ipsec", "min_spi", 10000)
+modparam("proto_ipsec", "max_spi", 10100)
+modparam("proto_ipsec", "allowed_algorithms", "hmac-sha-1-96=null")
+
+#### RTPENGINE module
+loadmodule "rtpengine.so"
+modparam("rtpengine", "rtpengine_sock", "udp:RTPENGINE_IP:2223")
+
+
+loadmodule "event_route.so"
+loadmodule "json.so"
+
+#### PRESENCE modules
+loadmodule "presence.so"
+loadmodule "presence_reginfo.so"
+loadmodule "pua.so"
+modparam("pua|presence","db_url", "mysql://opensips_pcscf:heslo@MYSQL_IP/opensips_pcscf")
+
+loadmodule "pua_reginfo.so"
+
+modparam("pua_reginfo", "ul_domain", "location")
+modparam("pua_reginfo", "ul_identities_key", "identities")
+modparam("pua_reginfo", "default_domain", "IMS_DOMAIN")
+modparam("pua_reginfo", "server_address", "sip:reginfo@pcscf.IMS_DOMAIN")
+
+
+
+##### N5 HTTP2 Modules and setting 
+
+loadmodule "rest_client.so"
+modparam("rest_client", "curl_timeout", 7)
+modparam("rest_client", "connection_timeout", 4)
+modparam("rest_client", "curl_http_version", 5)
+
+####### Routing Logic ########
+
+# main request routing logic
+
+route{
+	xlog("L_INFO", "[$ci] Start route time [$Tf] method ($rm) r-uri ($ru) \n");
+	set_via_handling("force-rport");
+
+	if (!mf_process_maxfwd_header(10)) {
+		send_reply(483,"Too Many Hops");
+		exit;
+	}
+
+	if (has_totag()) {
+
+		# handle hop-by-hop ACK (no routing required)
+		if ( is_method("ACK") && t_check_trans() ) {
+			t_relay();
+			exit;
+		}
+
+		# sequential request within a dialog should
+		# take the path determined by record-routing
+		if ( !loose_route() ) {
+			# we do record-routing for all our traffic, so we should not
+			# receive any sequential requests without Route hdr.
+			send_reply(404,"Not here");
+			exit;
+		}
+
+		if (is_method("BYE")) {
+			# do accounting even if the transaction fails
+			do_accounting("log","failed");
+      route(session_termination);
+		}
+
+		if (is_method("UPDATE")) {
+			if ($si != "SCSCF_IP")
+				rtpengine_offer("replace-origin");
+			else
+				t_on_reply("rtpengine_answer");
+		}
+
+		if (is_method("SUBSCRIBE|NOTIFY") && is_myself($rd)) {
+			route(handle_presence);
+			exit;
+		}
+
+		# route it out to whatever destination was set by loose_route()
+		# in $du (destination URI).
+		route(relay);
+		exit;
+	}
+
+	# CANCEL processing
+	if (is_method("CANCEL")) {
+		if (t_check_trans())
+			t_relay();
+		exit;
+	}
+
+	# absorb retransmissions, but do not create transaction
+	t_check_trans();
+
+	if (is_method("REGISTER")) {
+		xlog("L_INFO", "[$ci] Received REGISTER for $tu - relaying to I-CSCF\n");
+		append_hf("Path: <sip:term@pcscf.IMS_DOMAIN;lr>\r\n");
+
+		if ($hdr(Security-Client)) {
+			setflag("SEC_AGREE");
+			append_hf("P-Visited-Network-ID: IMS_DOMAIN\r\n");
+		}
+		t_on_reply("register_reply");
+	 	route(relay);
+		exit;
+	} else if (is_method("SUBSCRIBE|PUBLISH")) {
+		xlog("L_INFO", "[$ci] Received $rm for $tu - handling\n");
+		route(handle_presence);
+		exit;
+	} else if (is_method("INVITE")) {
+		if (loose_route()) {
+			xlog("L_INFO", "[$ci] Received INVITE for $tu - relaying to S-CSCF ($ru/$du)\n");
+			remove_hf("Security-Verify");
+			if (list_hdr_has_option("Require", "sec-agree"))
+				list_hdr_remove_option("Require", "sec-agree");
+			if (list_hdr_has_option("Proxy-Require", "sec-agree"))
+				list_hdr_remove_option("Proxy-Require", "sec-agree");
+			append_hf("P-Visited-Network-ID: IMS_DOMAIN\r\n");
+			$socket_out = "tcp:PCSCF_IP:5060";
+			$avp(si) = $si;
+      $avp(sub_id) = "imsi-" +  $fU;
+			rtpengine_offer("replace-origin");
+		} else {
+			xlog("L_INFO", "[$ci] Received INVITE for $tu - looking up from S-CSCF ($ru/$du/$tu)\n");
+			$rU = $(tU{s.select,0,;});
+      $avp(sub_id) = "imsi-" + $tU;
+			if (!lookup("location")) {
+				xlog("L_ERR", "[$ci] user $rU not found\n");
+				t_reply(404, "Not here");
+				exit;
+			}
+		}
+		route(extract_ip_port);
+		$avp(ip) = $var(ip);
+		$avp(port) = $var(port);
+		$avp(rtcp) = $var(rtcp);
+		$avp(stream) = $(rb{sdp.stream,0});
+		t_on_reply("invite_reply");
+		if (!record_route()) {
+			xlog("L_ERR", "[$ci] Cannot do record_route()\n");
+			t_reply(503, "Internal Error");
+			exit;
+		}
+		if (!create_dialog()) {
+			xlog("L_ERR", "[$ci] Cannot create_dialog()\n");
+			t_reply(503, "Internal Error");
+			exit;
+		}
+
+		if (!t_relay()) {
+			xlog("L_ERR", "[$ci] Cannot relay to $ru/$du\n");
+			t_reply(503, "Internal Error");
+			exit;
+		}
+		exit;
+	}
+
+	send_reply(405,"Method Not Allowed");
+	exit;
+}
+
+
+route[relay] {
+	if (!t_relay()) {
+		send_reply(500,"Internal Error");
+	}
+	exit;
+}
+
+onreply_route[register_reply] {
+	xlog("L_INFO","[$ci] Received REGISTER reply $rs from $si for $tu\n");
+	if ($T_reply_code == 401) {
+		if (!isflagset("SEC_AGREE") || ipsec_create())
+			route(dm_send_aar, "control");
+	} else if ($T_reply_code == 200) {
+		for ($var(item) in $(hdr(P-Associated-URI)[*])) {
+			$var(uri_len) = $(var(item){s.len}) - 2;
+			$var(uri) = $(var(item){s.substr, 1, $var(uri_len)});
+			if (!save("location", "no-reply, path-off", $var(uri))) {
+				xlog("L_ERR", "[$ci] could not save aor [$var(uri)]\n");
+			} else {
+				ul_add_key("location", "$tU@$td", "identities", "$var(uri)");
+			}
+		}
+		reginfo_update("$tU@$td");
+	}
+}
+
+onreply_route[invite_reply] {
+
+	if (!has_body_part("application/sdp")) {
+		xlog("L_INFO","[$ci] Received INVITE reply $rs from $si for $tu - without SDP\n");
+		return;
+	} else if (isflagset("INVITE_AAA")) {
+		xlog("L_INFO","[$ci] Received INVITE reply $rs from $si for $tu - AAA done\n");
+		return;
+	}
+	xlog("L_INFO","[$ci] Received INVITE reply $rs from $si for $tu - doing AAR\n");
+	route(extract_ip_port);
+	if ($avp(si) == NULL) {
+		rtpengine_answer("replace-origin");
+		$avp(si) = $si;
+		$var(tmp_ip) = $avp(ip);
+		$var(tmp_port) = $avp(port);
+		$avp(ip) := $var(ip);
+		$avp(port) := $var(port);
+		$var(ip) = $var(tmp_ip);
+		$var(port) = $var(tmp_port);
+	}
+	route(dm_send_aar, "audio");
+	setflag("INVITE_AAA");
+}
+
+onreply_route[rtpengine_answer] {
+	if (!has_body_part("application/sdp"))
+		return;
+	rtpengine_answer("replace-origin");
+}
+
+
+route[dm_send_aar] {
+
+	switch ($param(1)) {
+
+	case "control":
+#### Doing N5 QoS for Registration :
+  
+		if ($ipsec(ip) != NULL) {
+			$var(src_ip) = $ipsec_ue(ip);
+			$var(src_port) = $ipsec_ue(port-c);
+			$var(dst_ip) = $ipsec(ip);
+			$var(dst_port) = $ipsec(port-s);
+			$var(sess_port) = $ipsec_ue(port-s);
+		} else {
+			$var(src_ip) = $si;
+			$var(src_port) = $sp;
+			$var(dst_ip) = $socket_in(ip);
+			$var(dst_port) = $socket_in(port);
+			$var(sess_port) = $sp;
+		}
+
+    $var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
+    $var(dnn) = "ims";
+
+
+    $json(array1) := "[\"permit in ip from "+$var(src_ip)+" "+$var(src_port)+" to "+$var(dst_ip)+" "+$var(dst_port)+"\", \"permit out ip from "+$var(dst_ip)+" "+$var(dst_port)+" to "+$var(src_ip)+" "+$var(src_port)+"\"]";
+
+    $var(events) = "[{\"event\": \"QOS_NOTIF\", \"notifMethod\": \"PERIODIC\"}, {\"event\": \"ANI_REPORT\", \"notifMethod\": \"ONE_TIME\"}]";
+    $var(notifUri) = "http://172.22.0.21:7777";
+    $var(sponStatus) = "SPONSOR_DISABLED";
+    $var(supi) = "imsi-"+ $au;
+    $var(suppFeat) = "2";
+    $var(ueIpv4) = $var(src_ip);
+	
+	  $json(nf_reg_body) = "{
+                            \"ascReqData\": {
+                                \"afAppId\": \""+$var(afAppId)+"\",
+                                \"dnn\": \""+$var(dnn)+"\" ,
+                                \"medComponents\":{
+                                   \"0\":{
+                                       \"medCompN\":0,
+                                       \"qosReference\":\"qosVoNR\",
+                                       \"medType\":\"CONTROL\",
+                                       \"medSubComps\":{
+                                          \"0\": {
+                                              \"fNum\":0,
+                                              \"fDescs\": "+$json(array1)+",
+                                              \"fStatus\":\"ENABLED\",
+                                              \"flowUsage\":\"AF_SIGNALLING\"
+                                          }
+                                       }
+                                   }
+                                },
+                               \"evSubsc\":{ \"events\": "+$var(events)+"},
+                               \"notifUri\": \""+$var(notifUri)+"\" ,
+                               \"sponStatus\": \""+$var(sponStatus)+"\",
+                               \"supi\": \""+$var(supi)+"\",
+                               \"suppFeat\": \""+$var(suppFeat)+"\",
+                               \"ueIpv4\": \""+$var(ueIpv4)+"\"
+                                  }
+                         }";
+ 
+    rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_reg_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
+        xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
+    		xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
+        xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
+        xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");
+
+####### End N5 QoS for Registration
+		break;
+   
+	case "audio":
+#### Doing N5 QoS for Call :
+	   
+    $var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
+    $var(dnn) = "ims";
+
+
+    $json(array1) := "[\"permit in ip from "+$avp(ip)+" "+$avp(port)+" to "+$var(ip)+" "+$var(port)+"\", \"permit out ip from "+$var(ip)+" "+$var(port)+" to "+$avp(ip)+" "+$avp(port)+"\"]";
+    $json(array2) := "[\"permit in ip from "+$avp(ip)+" "+$avp(rtcp)+" to "+$var(ip)+" "+$var(rtcp)+"\", \"permit out ip from "+$var(ip)+" "+$var(rtcp)+" to "+$avp(ip)+" "+$avp(rtcp)+"\"]";
+	
+    $var(events) = "[{\"event\": \"QOS_NOTIF\", \"notifMethod\": \"PERIODIC\"}, {\"event\": \"ANI_REPORT\", \"notifMethod\": \"ONE_TIME\"}]";
+    $var(notifUri) = "http://172.22.0.21:7777";
+    $var(sponStatus) = "SPONSOR_DISABLED";
+    $var(supi) = $avp(sub_id);
+    $var(suppFeat) = "2";
+    $var(ueIpv4) = $avp(ip);
+	
+    $json(nf_call_body) = "{\"ascReqData\": { \"afAppId\": \""+$var(afAppId)+"\",
+    \"dnn\": \""+$var(dnn)+"\" ,
+    \"medComponents\":{ \"0\":{ \"medCompN\":0, \"qosReference\":\"qosVoNR\",\"medType\":\"AUDIO\", \"medSubComps\":{\"0\": { \"fNum\":1, \"fDescs\": "+$json(array1)+", \"fStatus\":\"ENABLED\", \"marBwDl\":\"5000 Kbps\", \"marBwUl\":\"3000 Kbps\", \"flowUsage\":\"NO_INFO\"},
+	\"1\":{\"fNum\":2, \"fDescs\": "+$json(array2)+", \"fStatus\":\"ENABLED\", \"marBwDl\":\"5000 Kbps\", \"marBwUl\":\"3000 Kbps\", \"flowUsage\":\"NO_INFO\"}}}},
+    \"evSubsc\":{ \"events\": "+$var(events)+"},
+    \"notifUri\": \""+$var(notifUri)+"\" ,
+    \"sponStatus\": \""+$var(sponStatus)+"\",
+    \"supi\": \""+$var(supi)+"\",
+    \"suppFeat\": \""+$var(suppFeat)+"\",
+    \"ueIpv4\": \""+$var(ueIpv4)+"\" }}";
+ 
+    rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_call_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
+		xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
+		xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
+		xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
+		xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");   
+
+		break;	   
+
+    }
+
+}
+
+route[session_termination] {
+	if ($si != "SCSCF_IP")
+		rtpengine_delete();
+
+			xlog("L_INFO","[$ci] Received BYE from $si for $tu - can't terminate N5: WIP N5 Termination logic\n");
+
+} 
+
+route[extract_ip_port] {
+	$var(ip) = $(rb{sdp.line,c}{s.select,2, });
+	$var(port) = $(rb{sdp.line,m}{s.select,1, });
+	$var(rtcp) = $(var(port){s.int}) + 1;
+}
+
+
+route[handle_presence] {
+	if (!t_newtran()){
+		sl_reply_error();
+		exit;
+	}
+	if ($hdr(Event) != "reg") {
+		xlog("L_ERR", "[$ci] Unhandled event $hdr(Event)\n");
+		send_reply(489, "Bad Event");
+		exit;
+	}
+
+	if (is_method("PUBLISH"))
+		handle_publish();
+	if (is_method("SUBSCRIBE"))
+		handle_subscribe();
+}

--- a/opensips_ims_pcscf/opensips_vonr.cfg
+++ b/opensips_ims_pcscf/opensips_vonr.cfg
@@ -349,7 +349,7 @@ route[dm_send_aar] {
 
 	case "control":
 #### Doing N5 QoS for Registration :
-  
+
 		if ($ipsec(ip) != NULL) {
 			$var(src_ip) = $ipsec_ue(ip);
 			$var(src_port) = $ipsec_ue(port-c);
@@ -364,102 +364,120 @@ route[dm_send_aar] {
 			$var(sess_port) = $sp;
 		}
 
-    $var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
-    $var(dnn) = "ims";
+		$var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
+		$var(dnn) = "ims";
+		$json(array1) := "[\"permit in ip from "+$var(src_ip)+" "+$var(src_port)+" to "+$var(dst_ip)+" "+$var(dst_port)+"\", \"permit out ip from "+$var(dst_ip)+" "+$var(dst_port)+" to "+$var(src_ip)+" "+$var(src_port)+"\"]";
+		$var(events) = "[{\"event\": \"QOS_NOTIF\", \"notifMethod\": \"PERIODIC\"}, {\"event\": \"ANI_REPORT\", \"notifMethod\": \"ONE_TIME\"}]";
+		$var(notifUri) = "http://172.22.0.21:7777";
+		$var(sponStatus) = "SPONSOR_DISABLED";
+		$var(supi) = "imsi-"+ $au;
+		$var(suppFeat) = "2";
+		$var(ueIpv4) = $var(src_ip);
 
-
-    $json(array1) := "[\"permit in ip from "+$var(src_ip)+" "+$var(src_port)+" to "+$var(dst_ip)+" "+$var(dst_port)+"\", \"permit out ip from "+$var(dst_ip)+" "+$var(dst_port)+" to "+$var(src_ip)+" "+$var(src_port)+"\"]";
-
-    $var(events) = "[{\"event\": \"QOS_NOTIF\", \"notifMethod\": \"PERIODIC\"}, {\"event\": \"ANI_REPORT\", \"notifMethod\": \"ONE_TIME\"}]";
-    $var(notifUri) = "http://172.22.0.21:7777";
-    $var(sponStatus) = "SPONSOR_DISABLED";
-    $var(supi) = "imsi-"+ $au;
-    $var(suppFeat) = "2";
-    $var(ueIpv4) = $var(src_ip);
-	
-	  $json(nf_reg_body) = "{
-                            \"ascReqData\": {
-                                \"afAppId\": \""+$var(afAppId)+"\",
-                                \"dnn\": \""+$var(dnn)+"\" ,
-                                \"medComponents\":{
-                                   \"0\":{
-                                       \"medCompN\":0,
-                                       \"qosReference\":\"qosVoNR\",
-                                       \"medType\":\"CONTROL\",
-                                       \"medSubComps\":{
-                                          \"0\": {
-                                              \"fNum\":0,
-                                              \"fDescs\": "+$json(array1)+",
-                                              \"fStatus\":\"ENABLED\",
-                                              \"flowUsage\":\"AF_SIGNALLING\"
-                                          }
-                                       }
-                                   }
-                                },
-                               \"evSubsc\":{ \"events\": "+$var(events)+"},
-                               \"notifUri\": \""+$var(notifUri)+"\" ,
-                               \"sponStatus\": \""+$var(sponStatus)+"\",
-                               \"supi\": \""+$var(supi)+"\",
-                               \"suppFeat\": \""+$var(suppFeat)+"\",
-                               \"ueIpv4\": \""+$var(ueIpv4)+"\"
-                                  }
-                         }";
- 
-    rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_reg_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
-        xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
-    		xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
-        xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
-        xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");
-
-####### End N5 QoS for Registration
-		break;
-   
-	case "audio":
-#### Doing N5 QoS for Call :
-	   
-    $var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
-    $var(dnn) = "ims";
-
-
-    $json(array1) := "[\"permit in ip from "+$avp(ip)+" "+$avp(port)+" to "+$var(ip)+" "+$var(port)+"\", \"permit out ip from "+$var(ip)+" "+$var(port)+" to "+$avp(ip)+" "+$avp(port)+"\"]";
-    $json(array2) := "[\"permit in ip from "+$avp(ip)+" "+$avp(rtcp)+" to "+$var(ip)+" "+$var(rtcp)+"\", \"permit out ip from "+$var(ip)+" "+$var(rtcp)+" to "+$avp(ip)+" "+$avp(rtcp)+"\"]";
-	
-    $var(events) = "[{\"event\": \"QOS_NOTIF\", \"notifMethod\": \"PERIODIC\"}, {\"event\": \"ANI_REPORT\", \"notifMethod\": \"ONE_TIME\"}]";
-    $var(notifUri) = "http://172.22.0.21:7777";
-    $var(sponStatus) = "SPONSOR_DISABLED";
-    $var(supi) = $avp(sub_id);
-    $var(suppFeat) = "2";
-    $var(ueIpv4) = $avp(ip);
-	
-    $json(nf_call_body) = "{\"ascReqData\": { \"afAppId\": \""+$var(afAppId)+"\",
-    \"dnn\": \""+$var(dnn)+"\" ,
-    \"medComponents\":{ \"0\":{ \"medCompN\":0, \"qosReference\":\"qosVoNR\",\"medType\":\"AUDIO\", \"medSubComps\":{\"0\": { \"fNum\":1, \"fDescs\": "+$json(array1)+", \"fStatus\":\"ENABLED\", \"marBwDl\":\"5000 Kbps\", \"marBwUl\":\"3000 Kbps\", \"flowUsage\":\"NO_INFO\"},
-	\"1\":{\"fNum\":2, \"fDescs\": "+$json(array2)+", \"fStatus\":\"ENABLED\", \"marBwDl\":\"5000 Kbps\", \"marBwUl\":\"3000 Kbps\", \"flowUsage\":\"NO_INFO\"}}}},
-    \"evSubsc\":{ \"events\": "+$var(events)+"},
-    \"notifUri\": \""+$var(notifUri)+"\" ,
-    \"sponStatus\": \""+$var(sponStatus)+"\",
-    \"supi\": \""+$var(supi)+"\",
-    \"suppFeat\": \""+$var(suppFeat)+"\",
-    \"ueIpv4\": \""+$var(ueIpv4)+"\" }}";
- 
-    rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_call_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
+		$json(nf_reg_body) = "{
+							\"ascReqData\":{
+								\"afAppId\": \""+$var(afAppId)+"\",
+								\"dnn\": \""+$var(dnn)+"\" ,
+								\"medComponents\":{
+												\"0\":{
+														\"medCompN\":0,
+														\"qosReference\":\"qosVoNR\",
+														\"medType\":\"CONTROL\",
+														\"medSubComps\":{ 
+																		\"0\": 
+																			{
+																			\"fNum\":0,
+																			\"fDescs\": "+$json(array1)+",
+																			\"fStatus\":\"ENABLED\",
+																			\"flowUsage\":\"AF_SIGNALLING\"
+																			}
+																		}
+														}
+													},
+							\"evSubsc\":{ \"events\": "+$var(events)+"},
+							\"notifUri\": \""+$var(notifUri)+"\" ,
+							\"sponStatus\": \""+$var(sponStatus)+"\",
+							\"supi\": \""+$var(supi)+"\",
+							\"suppFeat\": \""+$var(suppFeat)+"\",
+							\"ueIpv4\": \""+$var(ueIpv4)+"\"
+										}
+							}";
+		rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_reg_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
 		xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
 		xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
 		xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
-		xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");   
+		xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");
+		break;
 
-		break;	   
+####### End N5 QoS for Registration
 
-    }
+#### Doing N5 QoS for Call :
 
+	case "audio":
+		$var(afAppId) = "+g.3gpp.icsi-ref=\\\"urn%3Aurn-7%3A3gpp-service.ims.icsi.mmtel\\\"";
+		$var(dnn) = "ims";
+
+		$json(array1) := "[\"permit in ip from "+$avp(ip)+" "+$avp(port)+" to "+$var(ip)+" "+$var(port)+"\", \"permit out ip from "+$var(ip)+" "+$var(port)+" to "+$avp(ip)+" "+$avp(port)+"\"]";
+		$json(array2) := "[\"permit in ip from "+$avp(ip)+" "+$avp(rtcp)+" to "+$var(ip)+" "+$var(rtcp)+"\", \"permit out ip from "+$var(ip)+" "+$var(rtcp)+" to "+$avp(ip)+" "+$avp(rtcp)+"\"]";
+
+		$var(events) = "[{\"event\": \"QOS_NOTIF\", \"notifMethod\": \"PERIODIC\"}, {\"event\": \"ANI_REPORT\", \"notifMethod\": \"ONE_TIME\"}]";
+		$var(notifUri) = "http://172.22.0.21:7777";
+		$var(sponStatus) = "SPONSOR_DISABLED";
+		$var(supi) = $avp(sub_id);
+		$var(suppFeat) = "2";
+		$var(ueIpv4) = $avp(ip);
+	
+		$json(nf_call_body) = "{
+							\"ascReqData\": {
+								\"afAppId\": \""+$var(afAppId)+"\",
+								\"dnn\": \""+$var(dnn)+"\" ,
+								\"medComponents\":{ 
+												\"0\":{	
+														\"medCompN\":0,
+														\"qosReference\":\"qosVoNR\",
+														\"medType\":\"AUDIO\", 
+														\"medSubComps\":{
+																	\"0\": {
+																		\"fNum\":1, 
+																		\"fDescs\": "+$json(array1)+", 
+																		\"fStatus\":\"ENABLED\", 
+																		\"marBwDl\":\"5000 Kbps\", 
+																		\"marBwUl\":\"3000 Kbps\", 
+																		\"flowUsage\":\"NO_INFO\"
+																		},
+																	\"1\":{
+																		\"fNum\":2, 
+																		\"fDescs\": "+$json(array2)+", 
+																		\"fStatus\":\"ENABLED\", 
+																		\"marBwDl\":\"5000 Kbps\", 
+																		\"marBwUl\":\"3000 Kbps\", 
+																		\"flowUsage\":\"RTCP\"
+																			}
+																	}
+													}
+												},
+								\"evSubsc\":{ \"events\": "+$var(events)+"},
+								\"notifUri\": \""+$var(notifUri)+"\" ,
+								\"sponStatus\": \""+$var(sponStatus)+"\",
+								\"supi\": \""+$var(supi)+"\",
+								\"suppFeat\": \""+$var(suppFeat)+"\",
+								\"ueIpv4\": \""+$var(ueIpv4)+"\" 
+											}
+								}";
+	rest_post("http://172.22.0.27:7777/npcf-policyauthorization/v1/app-sessions", "$json_pretty(nf_call_body)", "application/json" , $var(resp), $var(ct), $var(rcode));
+	xlog("L_INFO", "N5 Response:  [$(hdr(location)) ] \n");
+	xlog("L_INFO", "N5 Response:  [$var(resp)] \n");
+	xlog("L_INFO", "N5 Response:  [$var(ct)] \n");
+	xlog("L_INFO", "N5 Response:  [$var(rcode)] \n");   
+	break;	   
+
+		}
 }
 
 route[session_termination] {
 	if ($si != "SCSCF_IP")
 		rtpengine_delete();
-
-			xlog("L_INFO","[$ci] Received BYE from $si for $tu - can't terminate N5: WIP N5 Termination logic\n");
-
+		xlog("L_INFO","[$ci] Received BYE from $si for $tu - can't terminate N5: WIP N5 Termination logic\n");
 } 
 
 route[extract_ip_port] {

--- a/opensips_ims_pcscf/pcscf_init.sh
+++ b/opensips_ims_pcscf/pcscf_init.sh
@@ -35,7 +35,7 @@ sh -c "echo 1 > /proc/sys/net/ipv6/ip_nonlocal_bind"
 mkdir -p /etc/opensips
 cp /mnt/pcscf/freeDiameter.conf /etc/opensips
 cp /mnt/pcscf/pcscf.dictionary /etc/opensips
-cp /mnt/pcscf/opensips.cfg /etc/opensips/opensips.cfg
+cp /mnt/pcscf/opensips.cfg /etc/opensips
 cp -r /mnt/pcscf/db /etc/opensips
 
 if [[ ${DEPLOY_MODE} == 5G ]];

--- a/opensips_ims_pcscf/pcscf_init.sh
+++ b/opensips_ims_pcscf/pcscf_init.sh
@@ -35,8 +35,13 @@ sh -c "echo 1 > /proc/sys/net/ipv6/ip_nonlocal_bind"
 mkdir -p /etc/opensips
 cp /mnt/pcscf/freeDiameter.conf /etc/opensips
 cp /mnt/pcscf/pcscf.dictionary /etc/opensips
-cp /mnt/pcscf/opensips.cfg /etc/opensips
+cp /mnt/pcscf/opensips.cfg /etc/opensips/opensips.cfg
 cp -r /mnt/pcscf/db /etc/opensips
+
+if [[ ${DEPLOY_MODE} == 5G ]];
+then
+    cp /mnt/pcscf/opensips_vonr.cfg /etc/opensips/opensips.cfg
+fi
 
 while ! mysqladmin ping -h ${MYSQL_IP} --silent; do
 	sleep 5;
@@ -62,6 +67,7 @@ then
 	fi
 fi
 
+
 sed -i 's|PCSCF_IP|'$PCSCF_IP'|g' /etc/opensips/opensips.cfg
 sed -i 's|IMS_DOMAIN|'$IMS_DOMAIN'|g' /etc/opensips/opensips.cfg
 sed -i 's|EPC_DOMAIN|'$EPC_DOMAIN'|g' /etc/opensips/opensips.cfg
@@ -76,6 +82,8 @@ sed -i 's|EPC_DOMAIN|'$EPC_DOMAIN'|g' /etc/opensips/freeDiameter.conf
 sed -i 's|PCRF_IP|'$PCRF_IP'|g' /etc/opensips/freeDiameter.conf
 sed -i 's|PCSCF_IP|'$PCSCF_IP'|g' /etc/opensips/freeDiameter.conf
 
+# Add Rest_Client module to the container
+apt-get update && apt-get install -y opensips-restclient-module 
 # Add static route to route traffic back to UE as there is not NATing
 apt-get update && apt-get install -y iproute2
 ip r add ${UE_IPV4_IMS} via ${UPF_IP}

--- a/sa-vonr-opensips-ims-depoly.yaml
+++ b/sa-vonr-opensips-ims-depoly.yaml
@@ -184,8 +184,8 @@ services:
       - "2152/udp"
       - "8805/udp"
       - "9091/tcp"
-    # ports:
-    #   - "2152:2152/udp"
+    ports:
+      - "2152:2152/udp"
     cap_add:
       - NET_ADMIN
     privileged: true
@@ -219,8 +219,8 @@ services:
       - "38412/sctp"
       - "7777/tcp"
       - "9091/tcp"
-    # ports:
-    #   - "38412:38412/sctp"
+    ports:
+      - "38412:38412/sctp"
     networks:
       default:
         ipv4_address: ${AMF_IP}
@@ -398,6 +398,8 @@ services:
     env_file:
       - .env
     environment:
+      - OPENSIPS_EXTRA_MODULES=opensips-restclient-module
+      - OPENSIPS_CLI=true
       - COMPONENT_NAME=icscf
     entrypoint: /mnt/icscf/icscf_init.sh
     depends_on:
@@ -423,6 +425,8 @@ services:
     env_file:
       - .env
     environment:
+      - OPENSIPS_EXTRA_MODULES=opensips-restclient-module
+      - OPENSIPS_CLI=true
       - COMPONENT_NAME=scscf
     entrypoint: /mnt/scscf/scscf_init.sh
     depends_on:
@@ -451,9 +455,10 @@ services:
     env_file:
       - .env
     environment:
-      - COMPONENT_NAME=pcscf
-    #  - DEPLOY_MODE=4G
       - OPENSIPS_EXTRA_MODULES=opensips-restclient-module
+      - OPENSIPS_CLI=true
+      - COMPONENT_NAME=pcscf
+      - DEPLOY_MODE=5G
     entrypoint: /mnt/pcscf/pcscf_init.sh
     depends_on:
       - dns
@@ -519,28 +524,6 @@ services:
     networks:
       default:
         ipv4_address: ${GRAFANA_IP}
-  ibcf:
-    build: ./ibcf
-    image: ibcf_voicemail
-    container_name: ibcf
-    dns: ${DNS_IP}
-    privileged: true
-    env_file:
-      - .env
-    volumes:
-      - ./ibcf:/mnt/ibcf
-    environment:
-      - COMPONENT_NAME=ibcf_voicemail
-    expose:
-      - "5090/tcp"
-      - "5090/udp"
-      - "10000-10100/udp"
-    ports:
-      - "5090:5090/tcp"
-      - "10000-10100:10000-10100/udp"      
-    networks:
-      default:
-        ipv4_address: ${IBCF_IP}         
 networks:
   default:
     name: docker_open5gs_default

--- a/sa-vonr-opensips-ims-depoly.yaml
+++ b/sa-vonr-opensips-ims-depoly.yaml
@@ -1,0 +1,556 @@
+services:
+  mongo:
+    image: mongo:6.0
+    container_name: mongo
+    command: --bind_ip 0.0.0.0
+    env_file:
+      - .env
+    volumes:
+      - mongodbdata:/data/db
+      - mongodbdata:/data/configdb
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "27017/udp"
+      - "27017/tcp"
+    networks:
+      default:
+        ipv4_address: ${MONGO_IP}
+  webui:
+    image: docker_open5gs
+    container_name: webui
+    depends_on:
+      - mongo
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=webui
+    volumes:
+      - ./webui:/mnt/webui
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "9999/tcp"
+    ports:
+      - "9999:9999/tcp"
+    networks:
+      default:
+        ipv4_address: ${WEBUI_IP}
+  nrf:
+    image: docker_open5gs
+    container_name: nrf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=nrf
+    volumes:
+      - ./nrf:/mnt/nrf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${NRF_IP}
+  scp:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+    container_name: scp
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=scp
+    volumes:
+      - ./scp:/mnt/scp
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${SCP_IP}
+  ausf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+    container_name: ausf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=ausf
+    volumes:
+      - ./ausf:/mnt/ausf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${AUSF_IP}
+  udr:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - mongo
+    container_name: udr
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=udr
+    volumes:
+      - ./udr:/mnt/udr
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${UDR_IP}
+  udm:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+    container_name: udm
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=udm
+    volumes:
+      - ./udm:/mnt/udm
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${UDM_IP}
+  smf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - amf
+    container_name: smf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=smf
+      - DEPLOY_MODE=5G
+    volumes:
+      - ./smf:/mnt/smf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "3868/udp"
+      - "3868/tcp"
+      - "3868/sctp"
+      - "5868/udp"
+      - "5868/tcp"
+      - "5868/sctp"
+      - "8805/udp"
+      - "2123/udp"
+      - "7777/tcp"
+      - "9091/tcp"
+    networks:
+      default:
+        ipv4_address: ${SMF_IP}
+  upf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - smf
+    container_name: upf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=upf
+    volumes:
+      - ./upf:/mnt/upf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "2152/udp"
+      - "8805/udp"
+      - "9091/tcp"
+    # ports:
+    #   - "2152:2152/udp"
+    cap_add:
+      - NET_ADMIN
+    privileged: true
+    sysctls:
+      - net.ipv4.ip_forward=1
+      #- net.ipv6.conf.all.disable_ipv6=0
+    networks:
+      default:
+        ipv4_address: ${UPF_IP}
+  amf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - ausf
+      - udm
+      - udr
+      - pcf
+      - bsf
+    container_name: amf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=amf
+    volumes:
+      - ./amf:/mnt/amf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "38412/sctp"
+      - "7777/tcp"
+      - "9091/tcp"
+    # ports:
+    #   - "38412:38412/sctp"
+    networks:
+      default:
+        ipv4_address: ${AMF_IP}
+  pcf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - mongo
+    container_name: pcf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=pcf
+    volumes:
+      - ./pcf:/mnt/pcf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+      - "9091/tcp"
+    networks:
+      default:
+        ipv4_address: ${PCF_IP}
+  bsf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - mongo
+    container_name: bsf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=bsf
+    volumes:
+      - ./bsf:/mnt/bsf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${BSF_IP}
+  nssf:
+    image: docker_open5gs
+    depends_on:
+      - nrf
+      - scp
+      - mongo
+    container_name: nssf
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=nssf
+    volumes:
+      - ./nssf:/mnt/nssf
+      - ./log:/open5gs/install/var/log/open5gs
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "7777/tcp"
+    networks:
+      default:
+        ipv4_address: ${NSSF_IP}
+  metrics:
+    build: ./metrics
+    image: docker_metrics
+    container_name: metrics
+    env_file:
+      - .env
+    volumes:
+      - ./metrics:/mnt/metrics
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "9090/tcp"
+    ports:
+      - "9090:9090/tcp"
+    networks:
+      default:
+        ipv4_address: ${METRICS_IP}
+  dns:
+    build: ./dns
+    image: docker_dns
+    container_name: dns
+    env_file:
+      - .env
+    volumes:
+      - ./dns:/mnt/dns
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "53/udp"
+    networks:
+      default:
+        ipv4_address: ${DNS_IP}
+  rtpengine:
+    build: ./rtpengine
+    image: docker_rtpengine
+    container_name: rtpengine
+    privileged: true
+    env_file:
+      - .env
+    volumes:
+      - ./rtpengine:/mnt/rtpengine
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    cap_add:
+      - NET_ADMIN
+    environment:
+      - TABLE=0
+      - INTERFACE=${RTPENGINE_IP}
+      - LISTEN_NG=${RTPENGINE_IP}:2223
+      - PIDFILE=/run/ngcp-rtpengine-daemon.pid
+      - PORT_MAX=50000
+      - PORT_MIN=49000
+      - NO_FALLBACK=no
+      - TOS=184
+    expose:
+      - "2223/udp"
+      - "49000-50000/udp"
+    networks:
+      default:
+        ipv4_address: ${RTPENGINE_IP}
+  mysql:
+    build: ./mysql
+    image: docker_mysql
+    container_name: mysql
+    env_file:
+      - .env
+    volumes:
+      - dbdata:/var/lib/mysql
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    expose:
+      - "3306/tcp"
+    networks:
+      default:
+        ipv4_address: ${MYSQL_IP}
+  pyhss:
+    build: ./pyhss
+    image: docker_pyhss
+    container_name: pyhss
+    dns: ${DNS_IP}
+    volumes:
+      - ./pyhss:/mnt/pyhss
+      - ./pyhss/logs:/pyhss/log/
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    depends_on:
+      - dns
+      - mysql
+    expose:
+      - "3868/udp"
+      - "3868/tcp"
+      - "8080/tcp"
+    ports:
+      - "8080:8080/tcp"
+    networks:
+      default:
+        ipv4_address: ${PYHSS_IP}
+  icscf:
+    image: opensips/opensips:ims-ce
+    container_name: icscf
+    dns: ${DNS_IP}
+    volumes:
+      - ./opensips_ims_icscf:/mnt/icscf
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=icscf
+    entrypoint: /mnt/icscf/icscf_init.sh
+    depends_on:
+      - dns
+      - mysql
+      - pyhss
+    expose:
+      - "3869/udp"
+      - "3869/tcp"
+      - "4060/udp"
+      - "4060/tcp"
+    networks:
+      default:
+        ipv4_address: ${ICSCF_IP}
+  scscf:
+    image: opensips/opensips:ims-ce
+    container_name: scscf
+    dns: ${DNS_IP}
+    volumes:
+      - ./opensips_ims_scscf:/mnt/scscf
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=scscf
+    entrypoint: /mnt/scscf/scscf_init.sh
+    depends_on:
+      - dns
+      - mysql
+      - pyhss
+    expose:
+      - "3870/udp"
+      - "3870/tcp"
+      - "6060/udp"
+      - "6060/tcp"
+    networks:
+      default:
+        ipv4_address: ${SCSCF_IP}
+  pcscf:
+    image: opensips/opensips:ims-ce
+    container_name: pcscf
+    dns: ${DNS_IP}
+    privileged: true
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - ./opensips_ims_pcscf:/mnt/pcscf
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=pcscf
+    #  - DEPLOY_MODE=4G
+      - OPENSIPS_EXTRA_MODULES=opensips-restclient-module
+    entrypoint: /mnt/pcscf/pcscf_init.sh
+    depends_on:
+      - dns
+      - mysql
+      - rtpengine
+      - icscf
+      - scscf
+    expose:
+      - "3871/udp"
+      - "3871/tcp"
+      - "5060/tcp"
+      - "5060/udp"
+      - "5100-5120/tcp"
+      - "5100-5120/udp"
+      - "6100-6120/tcp"
+      - "6100-6120/udp"
+    networks:
+      default:
+        ipv4_address: ${PCSCF_IP}
+  smsc:
+    image: docker_kamailio
+    container_name: smsc
+    dns: ${DNS_IP}
+    volumes:
+      - ./smsc:/mnt/smsc
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
+    environment:
+      - COMPONENT_NAME=smsc
+    depends_on:
+      - dns
+      - mysql
+    expose:
+      - "7090/udp"
+      - "7090/tcp"
+    networks:
+      default:
+        ipv4_address: ${SMSC_IP}
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: grafana
+    env_file:
+      - .env
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/:/etc/grafana/provisioning/
+      - ./grafana:/mnt/grafana
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USERNAME}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+      #- GF_INSTALL_PLUGINS=${GRAFANA_INSTALL_PLUGINS}
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_PATHS_DATA=/var/lib/grafana
+      - METRICS_IP=${METRICS_IP}
+    expose:
+      - "3000/tcp"
+    ports:
+      - "3000:3000/tcp"
+    networks:
+      default:
+        ipv4_address: ${GRAFANA_IP}
+  ibcf:
+    build: ./ibcf
+    image: ibcf_voicemail
+    container_name: ibcf
+    dns: ${DNS_IP}
+    privileged: true
+    env_file:
+      - .env
+    volumes:
+      - ./ibcf:/mnt/ibcf
+    environment:
+      - COMPONENT_NAME=ibcf_voicemail
+    expose:
+      - "5090/tcp"
+      - "5090/udp"
+      - "10000-10100/udp"
+    ports:
+      - "5090:5090/tcp"
+      - "10000-10100:10000-10100/udp"      
+    networks:
+      default:
+        ipv4_address: ${IBCF_IP}         
+networks:
+  default:
+    name: docker_open5gs_default
+    ipam:
+      config:
+        - subnet: ${TEST_NETWORK}
+volumes:
+  grafana_data:
+    name: grafana_data
+  mongodbdata:
+    name: docker_open5gs_mongodbdata
+  dbdata:
+    name: docker_open5gs_dbdata


### PR DESCRIPTION
Hi,

This is the CFG file that contains the N5 Routing Logic to enable VoNR for OpenSIPS IMS.
The following need to pay attention to : 
I did not find in docs that OpenSIPS support #!define/#!ifdef/#!endif so I created a separated file for VoNR and added the routing logic, also I removed all the related Rx logic from the VoNR file, I think you may need to add some adjustment to pcscf_init.sh file, to load the correct cfg depending on Deploy Mode.

The container needs the deb Package "opensips-restclient-module", this should not have any effect in case 4G config is used, therefore it could be safely installed in the docker image.

as usual take a look at the files adn write me back if there is any questions/issues :)

Best Regards    