### PR TITLE
Fix UPF on Fedora by using iptables-nft as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quite contrary to the name of the repository, this repository contains docker fi
 
 Docker host machine
 
-- Ubuntu 20.04 or 22.04
+- Ubuntu 22.04 or above
 
 Over-The-Air setups: 
 

--- a/upf/upf_init.sh
+++ b/upf/upf_init.sh
@@ -31,6 +31,10 @@ export LANG=C.UTF-8
 export IP_ADDR=$(awk 'END{print $1}' /etc/hosts)
 export IF_NAME=$(ip r | awk '/default/ { print $5 }')
 
+# use nftables instead of iptables
+update-alternatives --set iptables `which iptables-nft`
+update-alternatives --set ip6tables `which ip6tables-nft`
+
 # Remove ogstun and ogstun2 if they exist
 ip link delete ogstun
 ip link delete ogstun2


### PR DESCRIPTION
Fix #434, Most of the users should already be running Ubuntu 22.04 and above (otherwise their oai/ueransim/srsran containers won't work). So this should be a safe workaround until base image also moved to ubuntu jammy.