### PR TITLE
[IMS] Opensips, Samsung UE Register Failure Fix

### DIFF
--- a/opensips_ims_pcscf/opensips.cfg
+++ b/opensips_ims_pcscf/opensips.cfg
@@ -128,7 +128,7 @@ modparam("aaa_diameter", "aaa_url",
 
 modparam("proto_ipsec", "min_spi", 10000)
 modparam("proto_ipsec", "max_spi", 10100)
-modparam("proto_ipsec", "allowed_algorithms", "hmac-sha-1-96=null")
+modparam("proto_ipsec", "allowed_algorithms", "hmac-sha-1-96=null, hmac-md5-96=null")
 
 #### RTPENGINE module
 loadmodule "rtpengine.so"

--- a/opensips_ims_pcscf/opensips_vonr.cfg
+++ b/opensips_ims_pcscf/opensips_vonr.cfg
@@ -121,7 +121,7 @@ modparam("dispatcher", "db_url", "text:///etc/opensips/db")
 
 modparam("proto_ipsec", "min_spi", 10000)
 modparam("proto_ipsec", "max_spi", 10100)
-modparam("proto_ipsec", "allowed_algorithms", "hmac-sha-1-96=null")
+modparam("proto_ipsec", "allowed_algorithms", "hmac-sha-1-96=null, hmac-md5-96=null")
 
 #### RTPENGINE module
 loadmodule "rtpengine.so"


### PR DESCRIPTION
* If using the OpenSIP as IMS, the Samsung UE Register was failing due to the algorithm was not defined in the allowed list in PCSCF.

![image](https://github.com/user-attachments/assets/b08048fb-e632-4ff9-b97b-e13cffc9242b)

* Below  is the **_Security-Client_** header of Samsung UE

```
 […]Security-Client: ipsec-3gpp;prot=esp;mod=trans;spi-c=74618;spi-s=74619;port-c=8001;port-s=8000;alg=hmac-md5-96;ealg=des-ede3-cbc, ipsec-3gpp;prot=esp;mod=trans;spi-c=74618;spi-s=74619;port-c=8001;port-s=8000;>
    [Security-mechanism]: ipsec-3gpp
    prot: esp
    mod=trans
    spi-c:  *****
    spi-s:  *****
    port-c: 8001
    port-s: 8000
    alg: hmac-md5-96
    ealg: des-ede3-cbc
    [Security-mechanism]: ipsec-3gpp
    prot: esp
    mod=trans
    spi-c:  *****
    spi-s:  *****
    port-c: 8001
    port-s: 8000
    alg: hmac-md5-96
    ealg: aes-cbc
    [Security-mechanism]: ipsec-3gpp
    prot: esp
    mod=trans
    spi-c:  *****
    spi-s:  *****
    port-c: 8001
    port-s: 8000
    alg: hmac-md5-96
    ealg: null
```