### PR TITLE
Add TUN/TAP Mode Selection Support for UPF Interface Configuration

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,9 @@ SMF_DNS1=8.8.8.8
 SMF_DNS2=8.8.4.4
 
 # UPF
+# Allowed values for UPF_TUNTAP_MODE are 'tun' or 'tap'
+# if used 'tap' as IF mode, then UE_INTERNET_IF_NAME and UE_IMS_IF_NAME must contain string 'tap'
+UPF_TUNTAP_MODE=tun
 UPF_IP=172.22.0.8
 UPF_ADVERTISE_IP=172.22.0.8
 
@@ -137,9 +140,11 @@ GRAFANA_PASSWORD=open5gs
 
 # UE IPv4 Subnet Range for APN=internet
 UE_IPV4_INTERNET=192.168.100.0/24
+UE_INTERNET_IF_NAME=ogstun
 
 # UE IPv4 Subnet Range for APN=ims
 UE_IPV4_IMS=192.168.101.0/24
+UE_IMS_IF_NAME=ogstun2
 
 # Maximum Number of UEs
 MAX_NUM_UE=1024

--- a/upf/upf.yaml
+++ b/upf/upf.yaml
@@ -21,19 +21,19 @@ upf:
       - subnet: UE_IPV4_INTERNET_SUBNET
         gateway: UE_IPV4_INTERNET_TUN_IP
         dnn: internet
-        dev: ogstun
+        dev: UE_INTERNET_IF_NAME
       - subnet: 2001:230:cafe::/48
         gateway: 2001:230:cafe::1
         dnn: internet
-        dev: ogstun
+        dev: UE_INTERNET_IF_NAME
       - subnet: UE_IPV4_IMS_SUBNET
         gateway: UE_IPV4_IMS_TUN_IP
         dnn: ims
-        dev: ogstun2
+        dev: UE_IMS_IF_NAME
       - subnet: 2001:230:babe::/48
         gateway: 2001:230:babe::1
         dnn: ims
-        dev: ogstun2
+        dev: UE_IMS_IF_NAME
     metrics:
       server:
         - address: UPF_IP


### PR DESCRIPTION
### Description:

This MR introduces support for configurable TUN/TAP interface modes (`tun` or `tap`) in the UPF module of the Open5GS Docker setup. This enhancement allows greater flexibility in UE traffic routing setups and interface emulation.

### Key Changes:

* **`.env`**:

  * Added `UPF_TUNTAP_MODE`, `UE_INTERNET_IF_NAME`, and `UE_IMS_IF_NAME` variables to support interface mode and name customization.

* **`upf_init.sh`**:

  * Refactored interface initialization logic to support both TUN and TAP modes.
  * Added input validation for `UPF_TUNTAP_MODE` to avoid misconfigurations.
  * Interface names are now dynamic, using environment variables.

* **`tun_if.py`**:

  * Introduced new CLI argument `--tun_ifmode` (values: `tun` or `tap`).
  * Interface creation logic updated to use the selected mode dynamically.

* **`upf.yaml`**:

  * Replaced hardcoded interface names (`ogstun`, `ogstun2`) with environment variable placeholders (`UE_INTERNET_IF_NAME`, `UE_IMS_IF_NAME`) for dynamic substitution.

### Benefits:

* Enables experimentation and deployment with TAP interfaces, which may offer better performance in certain L2 traffic scenarios.
* Makes the UPF interface setup more modular and adaptable to various testing and deployment needs.

