### PR TITLE
kamailio: set log_name

### DIFF
--- a/icscf/kamailio_icscf.cfg
+++ b/icscf/kamailio_icscf.cfg
@@ -44,7 +44,7 @@ sip_warning=no
 
 user_agent_header="User-Agent: Kamailio I-CSCF"
 server_header="Server: Kamailio I-CSCF"
-
+log_name="icscf"
 log_prefix="{$mt $hdr(CSeq) $ci} "
 
 /* comment the next line to enable the auto discovery of local aliases

--- a/pcscf/kamailio_pcscf.cfg
+++ b/pcscf/kamailio_pcscf.cfg
@@ -73,6 +73,7 @@ user_agent_header="User-Agent: TelcoSuite Proxy-CSCF"
 server_header="Server: TelcoSuite Proxy-CSCF"
 
 log_facility=LOG_LOCAL0
+log_name="pcscf"
 log_prefix="{$mt $hdr(CSeq) $ci} "
 
 fork=yes

--- a/scscf/kamailio_scscf.cfg
+++ b/scscf/kamailio_scscf.cfg
@@ -52,7 +52,7 @@ alias=HOSTNAME
 
 user_agent_header="User-Agent: Kamailio S-CSCF"
 server_header="Server: Kamailio S-CSCF"
-
+log_name="scscf"
 log_prefix="{$mt $hdr(CSeq) $ci} "
 
 /* comment the next line to enable the auto discovery of local aliases

--- a/smsc/kamailio_smsc.cfg
+++ b/smsc/kamailio_smsc.cfg
@@ -23,6 +23,7 @@ children=4
 
 user_agent_header="User-Agent: Kamailio SMSC"
 server_header="Server: Kamailio SMSC"
+log_name="smsc"
 
 /* comment the next line to enable the auto discovery of local aliases
    based on reverse DNS on IPs (default on) */


### PR DESCRIPTION
instead of useless binary kamailio path, use the logical component name