### PR TITLE
kamailio: use mod_level to refine debug level logs

### DIFF
--- a/icscf/kamailio_icscf.cfg
+++ b/icscf/kamailio_icscf.cfg
@@ -32,15 +32,9 @@ listen=tcp:127.0.0.1:4060
 #!endif
 
 ####### Global Parameters #########
-#!ifdef WITH_DEBUG
-debug=5
-log_stderror=yes
-sip_warning=yes
-#!else
 debug=2
 log_stderror=no
 sip_warning=no
-#!endif
 
 user_agent_header="User-Agent: Kamailio I-CSCF"
 server_header="Server: Kamailio I-CSCF"
@@ -198,8 +192,12 @@ modparam("xmlrpc", "url_match", "^/RPC")
 modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")
 
 #!ifdef WITH_DEBUG
-#!ifdef WITH_DEBUG_TRACE
 # ----- debugger params -----
+modparam("debugger", "mod_hash_size", 5)
+modparam("debugger", "mod_level_mode", 1)
+modparam("debugger", "mod_level", "cdp=3")
+modparam("debugger", "mod_level", "ims_icscf=3")
+#!ifdef WITH_DEBUG_TRACE
 modparam("debugger", "cfgtrace", 1)
 #!endif
 #!endif

--- a/pcscf/kamailio_pcscf.cfg
+++ b/pcscf/kamailio_pcscf.cfg
@@ -30,14 +30,8 @@ import_file "pcscf.cfg"
 #!define FLT_CAPTURE 5
 
 ####### Global Parameters #########
-
-#!ifdef WITH_DEBUG
-debug=4
-log_stderror=yes
-#!else
 debug=2
 log_stderror=no
-#!endif
 
 memdbg=5
 memlog=5

--- a/scscf/kamailio_scscf.cfg
+++ b/scscf/kamailio_scscf.cfg
@@ -34,15 +34,9 @@
 
 include_file "scscf.cfg"
 
-#!ifdef WITH_DEBUG
-debug=5
-log_stderror=no
-sip_warning=yes
-#!else
 debug=2
 log_stderror=no
 sip_warning=no
-#!endif
 
 #!ifdef WITH_XMLRPC
 listen=tcp:127.0.0.1:6060


### PR DESCRIPTION
Enabling WITH_DEBUG is spamming syslog with core debug logs