### PR TITLE
kamailio: improve log

### DIFF
--- a/icscf/kamailio_icscf.cfg
+++ b/icscf/kamailio_icscf.cfg
@@ -196,6 +196,7 @@ modparam("ctl", "binrpc", "unix:/var/run/kamailio/kamailio_ctl")
 # ----- debugger params -----
 modparam("debugger", "mod_hash_size", 5)
 modparam("debugger", "mod_level_mode", 1)
+modparam("debugger", "mod_level", "xlog=3")
 modparam("debugger", "mod_level", "cdp=3")
 modparam("debugger", "mod_level", "ims_icscf=3")
 #!ifdef WITH_DEBUG_TRACE

--- a/icscf/kamailio_icscf.cfg
+++ b/icscf/kamailio_icscf.cfg
@@ -39,7 +39,8 @@ sip_warning=no
 user_agent_header="User-Agent: Kamailio I-CSCF"
 server_header="Server: Kamailio I-CSCF"
 log_name="icscf"
-log_prefix="{$mt $hdr(CSeq) $ci} "
+log_prefix_mode=1
+log_prefix="{$mt $hdr(CSeq) $ci $cfg(route)} "
 
 /* comment the next line to enable the auto discovery of local aliases
    based on reverse DNS on IPs (default on) */

--- a/pcscf/kamailio_pcscf.cfg
+++ b/pcscf/kamailio_pcscf.cfg
@@ -68,7 +68,8 @@ server_header="Server: TelcoSuite Proxy-CSCF"
 
 log_facility=LOG_LOCAL0
 log_name="pcscf"
-log_prefix="{$mt $hdr(CSeq) $ci} "
+log_prefix_mode=1
+log_prefix="{$mt $hdr(CSeq) $ci $cfg(route)} "
 
 fork=yes
 children=4

--- a/pcscf/kamailio_pcscf.cfg
+++ b/pcscf/kamailio_pcscf.cfg
@@ -248,6 +248,7 @@ loadmodule "htable.so"
 #loadmodule "debugger.so"
 modparam("debugger", "mod_hash_size", 5)
 modparam("debugger", "mod_level_mode", 1)
+modparam("debugger", "mod_level", "xlog=3")
 modparam("debugger", "mod_level", "rtpengine=3")
 modparam("debugger", "mod_level", "ims_qos=3")
 #!ifdef WITH_IPSEC

--- a/scscf/kamailio_scscf.cfg
+++ b/scscf/kamailio_scscf.cfg
@@ -47,7 +47,8 @@ alias=HOSTNAME
 user_agent_header="User-Agent: Kamailio S-CSCF"
 server_header="Server: Kamailio S-CSCF"
 log_name="scscf"
-log_prefix="{$mt $hdr(CSeq) $ci} "
+log_prefix_mode=1
+log_prefix="{$mt $hdr(CSeq) $ci $cfg(route)} "
 
 /* comment the next line to enable the auto discovery of local aliases
 	 based on reverse DNS on IPs (default on) */

--- a/scscf/kamailio_scscf.cfg
+++ b/scscf/kamailio_scscf.cfg
@@ -158,6 +158,7 @@ loadmodule "siptrace.so"
 loadmodule "debugger.so"
 modparam("debugger", "mod_hash_size", 5)
 modparam("debugger", "mod_level_mode", 1)
+modparam("debugger", "mod_level", "xlog=3")
 modparam("debugger", "mod_level", "ims_usrloc_scscf=3")
 modparam("debugger", "mod_level", "ims_registrar_scscf=3")
 modparam("debugger", "mod_level", "ims_auth=3")

--- a/smsc/kamailio_smsc.cfg
+++ b/smsc/kamailio_smsc.cfg
@@ -24,6 +24,8 @@ children=4
 user_agent_header="User-Agent: Kamailio SMSC"
 server_header="Server: Kamailio SMSC"
 log_name="smsc"
+log_prefix_mode=1
+log_prefix="{$mt $hdr(CSeq) $ci $cfg(route)} "
 
 /* comment the next line to enable the auto discovery of local aliases
    based on reverse DNS on IPs (default on) */


### PR DESCRIPTION
* adding route name to log_prefix
```icscf[439986]: ERROR: {1 1 REGISTER c5cd8ca311198f6b@10.46.0.12 DEFAULT_ROUTE} <script>: ```
* enable xlog debug level if WITH_DEBUG is enabled