### PR TITLE
[p|s]cscf: add missing corex module

### DIFF
--- a/pcscf/kamailio_pcscf.cfg
+++ b/pcscf/kamailio_pcscf.cfg
@@ -147,6 +147,7 @@ mpath="/usr/lib64/kamailio/modules_k/:/usr/lib64/kamailio/modules/:/usr/lib/kama
 # Fifo Module
 # Kamailio Extensions (e.g. MI:uptime, MI:version, cfg:isflagset etc.)
 loadmodule "kex.so"
+loadmodule "corex.so"
 # Transaction Module
 loadmodule "tm.so"
 loadmodule "tmx.so"

--- a/scscf/kamailio_scscf.cfg
+++ b/scscf/kamailio_scscf.cfg
@@ -113,6 +113,7 @@ loadmodule "xlog.so"
 loadmodule "sanity.so"
 loadmodule "siputils.so"
 loadmodule "kex.so"
+loadmodule "corex.so"
 loadmodule "tmx.so"
 loadmodule "pike.so"
 #!ifdef DB_URL


### PR DESCRIPTION
after 7e6d607efd3ccb86202850b0aea1d882854385a8 corex is needed for print route name in prefix

> Jul 31 11:48:14 pcscf[1231278]: ERROR: <core> [core/pvapi.c:913]: pv_parse_spec2(): error searching pvar "cfg"
> Jul 31 11:48:14 pcscf[1231278]: ERROR: <core> [core/pvapi.c:1092]: pv_parse_spec2(): wrong char [r/114] in [$cfg(route)] at [5 (5)]
> Jul 31 11:48:14 pcscf[1231278]: ERROR: <core> [core/dprint.c:502]: log_prefix_init(): wrong format[{$mt $hdr(CSeq) $ci $cfg(route)} ]