### PR TITLE
pcscf: ims_registrar_pcscf no longer depends of ims_ipsec_pcscf

### DIFF
--- a/pcscf/kamailio_pcscf.cfg
+++ b/pcscf/kamailio_pcscf.cfg
@@ -171,8 +171,9 @@ loadmodule "statistics.so"
 
 loadmodule "ims_dialog.so"
 loadmodule "ims_usrloc_pcscf.so"
-# Following module is required even in case of IPSec being disabled.
+#!ifdef WITH_IPSEC
 loadmodule "ims_ipsec_pcscf.so"
+#!endif
 loadmodule "ims_registrar_pcscf.so"
 
 #!ifdef WITH_XMLRPC


### PR DESCRIPTION
Should be loaded if ipsec is required

* since kamailio 6.0.0 https://github.com/kamailio/kamailio/commit/898308334982b39d668410b51b90835b57b8a4c2