### PR TITLE
smsc: add missing corex module

### DIFF
--- a/smsc/kamailio_smsc.cfg
+++ b/smsc/kamailio_smsc.cfg
@@ -47,6 +47,7 @@ mpath="/usr/lib64/kamailio/modules_k/:/usr/lib64/kamailio/modules/:/usr/lib/kama
 
 loadmodule "tm.so"
 loadmodule "tmx.so"
+loadmodule "corex.so"
 loadmodule "smsops.so"
 loadmodule "xlog.so"
 loadmodule "maxfwd.so"


### PR DESCRIPTION
after 7e6d607 corex is needed for print route name in prefix

> 0(30) ERROR: <core> [core/pvapi.c:913]: pv_parse_spec2(): error searching pvar "cfg"
> 0(30) ERROR: <core> [core/pvapi.c:1092]: pv_parse_spec2(): wrong char [r/114] in [$cfg(route)] at [5 (5)]
> 0(30) ERROR: <core> [core/dprint.c:502]: log_prefix_init(): wrong format[{$mt $hdr(CSeq) $ci $cfg(route)} ]